### PR TITLE
Python distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,14 @@
-graft cmake common cpc fi hll kll theta python
-global-include CMakeLists.txt *.cpp *.c *.hpp *.h *.bin
+global-include CMakeLists.txt
+global-include .cmake
+global-include .cpp
+global-include .c
+global-include .hpp
+global-include .h
+global-include .bin
+global-include .cmake
+
 global-exclude .git*
-prune python/pybind11
+
+recursive-include python/pybind11 *
+
+graft cmake common cpc fi hll kll theta python

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+graft cmake common cpc fi hll kll theta python
+global-include CMakeLists.txt *.cpp *.c *.hpp *.h *.bin
+global-exclude .git*
+prune python/pybind11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,4 @@
 requires = ["wheel",
             "setuptools >= 30.3.0",
             "setuptools_scm",
-            "cmake >= 3.12",
-            "pybind11"]
+            "cmake >= 3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
-requires = ["wheel", "setuptools", "cmake >= 3.12", "pybind11"]
+requires = ["wheel",
+            "setuptools >= 30.3.0",
+            "setuptools_scm",
+            "cmake >= 3.12",
+            "pybind11"]

--- a/python/src/cpc_wrapper.cpp
+++ b/python/src/cpc_wrapper.cpp
@@ -30,24 +30,24 @@ namespace py = pybind11;
 namespace datasketches {
 namespace python {
 
-cpc_sketch* CpcSketch_deserialize(py::bytes skBytes) {
+cpc_sketch* cpc_sketch_deserialize(py::bytes skBytes) {
   std::string skStr = skBytes; // implicit cast
   cpc_sketch_unique_ptr sk = cpc_sketch::deserialize(skStr.c_str(), skStr.length());
   return sk.release();
 }
 
-py::object CpcSketch_serialize(const cpc_sketch& sk) {
+py::object cpc_sketch_serialize(const cpc_sketch& sk) {
   auto serResult = sk.serialize();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
 
-std::string CpcSketch_toString(const cpc_sketch& sk) {
+std::string cpc_sketch_to_string(const cpc_sketch& sk) {
   std::ostringstream ss;
   ss << sk;
   return ss.str();
 }
 
-cpc_sketch* CpcUnion_getResult(const cpc_union& u) {
+cpc_sketch* cpc_union_get_result(const cpc_union& u) {
   auto sk = u.get_result();
   return sk.release();
 }
@@ -63,9 +63,9 @@ void init_cpc(py::module &m) {
   py::class_<cpc_sketch>(m, "cpc_sketch")
     .def(py::init<uint8_t, uint64_t>(), py::arg("lg_k"), py::arg("seed")=DEFAULT_SEED)
     .def(py::init<const cpc_sketch&>())
-    .def("__str__", &dspy::CpcSketch_toString)
-    .def("serialize", &dspy::CpcSketch_serialize)
-    .def_static("deserialize", &dspy::CpcSketch_deserialize)
+    .def("__str__", &dspy::cpc_sketch_to_string)
+    .def("serialize", &dspy::cpc_sketch_serialize)
+    .def_static("deserialize", &dspy::cpc_sketch_deserialize)
     .def<void (cpc_sketch::*)(uint64_t)>("update", &cpc_sketch::update, py::arg("datum"))
     .def<void (cpc_sketch::*)(double)>("update", &cpc_sketch::update, py::arg("datum"))
     .def<void (cpc_sketch::*)(const std::string&)>("update", &cpc_sketch::update, py::arg("datum"))
@@ -79,6 +79,6 @@ void init_cpc(py::module &m) {
     .def(py::init<uint8_t, uint64_t>(), py::arg("lg_k"), py::arg("seed")=DEFAULT_SEED)
     .def(py::init<const cpc_union&>())
     .def("update", &cpc_union::update, py::arg("sketch"))
-    .def("get_result", &dspy::CpcUnion_getResult)
+    .def("get_result", &dspy::cpc_union_get_result)
     ;
 }

--- a/python/src/fi_wrapper.cpp
+++ b/python/src/fi_wrapper.cpp
@@ -28,13 +28,13 @@ namespace datasketches {
 namespace python {
 
 template<typename T>
-frequent_items_sketch<T> FISketch_deserialize(py::bytes skBytes) {
+frequent_items_sketch<T> fi_sketch_deserialize(py::bytes skBytes) {
   std::string skStr = skBytes; // implicit cast  
   return frequent_items_sketch<T>::deserialize(skStr.c_str(), skStr.length());
 }
 
 template<typename T>
-py::object FISketch_serialize(const frequent_items_sketch<T>& sk) {
+py::object fi_sketch_serialize(const frequent_items_sketch<T>& sk) {
   auto serResult = sk.serialize();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
@@ -42,12 +42,12 @@ py::object FISketch_serialize(const frequent_items_sketch<T>& sk) {
 // maybe possible to disambiguate the static vs method get_epsilon calls, but
 // this is easier for now
 template<typename T>
-double FISketch_getGenericEpsilon(uint8_t lg_max_map_size) {
+double fi_sketch_get_generic_epsilon(uint8_t lg_max_map_size) {
   return frequent_items_sketch<T>::get_epsilon(lg_max_map_size);
 }
 
 template<typename T>
-py::list FISketch_getFrequentItems(const frequent_items_sketch<T>& sk,
+py::list fi_sketch_get_frequent_items(const frequent_items_sketch<T>& sk,
                                    frequent_items_error_type err_type,
                                    uint64_t threshold = 0) {
   if (threshold == 0) { threshold = sk.get_maximum_error(); }
@@ -65,7 +65,7 @@ py::list FISketch_getFrequentItems(const frequent_items_sketch<T>& sk,
 }
 
 template<typename T>
-std::string FISketch_toString(const frequent_items_sketch<T>& sk,
+std::string fi_sketch_to_string(const frequent_items_sketch<T>& sk,
                               bool print_items = false) {
   std::ostringstream ss;
   sk.to_stream(ss, print_items);
@@ -83,10 +83,10 @@ void bind_fi_sketch(py::module &m, const char* name) {
 
   py::class_<frequent_items_sketch<T>>(m, name)
     .def(py::init<uint8_t>(), py::arg("lg_max_k"))
-    .def("__str__", &dspy::FISketch_toString<T>, py::arg("print_items")=false)
-    .def("to_string", &dspy::FISketch_toString<T>, py::arg("print_items")=false)
+    .def("__str__", &dspy::fi_sketch_to_string<T>, py::arg("print_items")=false)
+    .def("to_string", &dspy::fi_sketch_to_string<T>, py::arg("print_items")=false)
     .def("update", (void (frequent_items_sketch<T>::*)(const T&, uint64_t)) &frequent_items_sketch<T>::update, py::arg("item"), py::arg("weight")=1)
-    .def("get_frequent_items", &dspy::FISketch_getFrequentItems<T>, py::arg("err_type"), py::arg("threshold")=0)
+    .def("get_frequent_items", &dspy::fi_sketch_get_frequent_items<T>, py::arg("err_type"), py::arg("threshold")=0)
     .def("merge", &frequent_items_sketch<T>::merge)
     .def("is_empty", &frequent_items_sketch<T>::is_empty)
     .def("get_num_active_items", &frequent_items_sketch<T>::get_num_active_items)
@@ -95,11 +95,11 @@ void bind_fi_sketch(py::module &m, const char* name) {
     .def("get_lower_bound", &frequent_items_sketch<T>::get_lower_bound, py::arg("item"))
     .def("get_upper_bound", &frequent_items_sketch<T>::get_upper_bound, py::arg("item"))
     .def("get_sketch_epsilon", (double (frequent_items_sketch<T>::*)(void) const) &frequent_items_sketch<T>::get_epsilon)
-    .def_static("get_epsilon_for_lg_size", &dspy::FISketch_getGenericEpsilon<T>, py::arg("lg_max_map_size"))
+    .def_static("get_epsilon_for_lg_size", &dspy::fi_sketch_get_generic_epsilon<T>, py::arg("lg_max_map_size"))
     .def_static("get_apriori_error", &frequent_items_sketch<T>::get_apriori_error, py::arg("lg_max_map_size"), py::arg("estimated_total_weight"))
     .def("get_serialized_size_bytes", &frequent_items_sketch<T>::get_serialized_size_bytes)
-    .def("serialize", &dspy::FISketch_serialize<T>)
-    .def_static("deserialize", &dspy::FISketch_deserialize<T>)
+    .def("serialize", &dspy::fi_sketch_serialize<T>)
+    .def_static("deserialize", &dspy::fi_sketch_deserialize<T>)
     ;
 }
 

--- a/python/src/hll_wrapper.cpp
+++ b/python/src/hll_wrapper.cpp
@@ -26,32 +26,32 @@ namespace py = pybind11;
 namespace datasketches {
 namespace python {
 
-HllSketch<> HllSketch_deserialize(py::bytes skBytes) {
+HllSketch<> hll_sketch_deserialize(py::bytes skBytes) {
   std::string skStr = skBytes; // implicit cast  
   return HllSketch<>::deserialize(skStr.c_str(), skStr.length());
 }
 
-py::object HllSketch_serializeCompact(const HllSketch<>& sk) {
+py::object hll_sketch_serialize_compact(const HllSketch<>& sk) {
   auto serResult = sk.serializeCompact();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
 
-py::object HllSketch_serializeUpdatable(const HllSketch<>& sk) {
+py::object hll_sketch_serialize_updatable(const HllSketch<>& sk) {
   auto serResult = sk.serializeUpdatable();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
 
-HllUnion<> HllUnion_deserialize(py::bytes uBytes) {
+HllUnion<> hll_union_deserialize(py::bytes uBytes) {
   std::string uStr = uBytes; // implicit cast
   return HllUnion<>::deserialize(uStr.c_str(), uStr.length());
 }
 
-py::object HllUnion_serializeCompact(const HllUnion<>& u) {
+py::object hll_union_serialize_compact(const HllUnion<>& u) {
   auto serResult = u.serializeCompact();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
 
-py::object HllUnion_serializeUpdatable(const HllUnion<>& u) {
+py::object hll_union_serialize_updatable(const HllUnion<>& u) {
   auto serResult = u.serializeUpdatable();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
@@ -74,9 +74,9 @@ void init_hll(py::module &m) {
     .def(py::init<int>(), py::arg("lg_k"))
     .def(py::init<int, TgtHllType>(), py::arg("lg_k"), py::arg("tgt_hll_type"))
     .def(py::init<int, TgtHllType, bool>(), py::arg("lg_k"), py::arg("tgt_hll_type"), py::arg("start_max_size")=false)
-    .def_static("deserialize", &dspy::HllSketch_deserialize)
-    .def("serialize_compact", &dspy::HllSketch_serializeCompact)
-    .def("serialize_updatable", &dspy::HllSketch_serializeUpdatable)
+    .def_static("deserialize", &dspy::hll_sketch_deserialize)
+    .def("serialize_compact", &dspy::hll_sketch_serialize_compact)
+    .def("serialize_updatable", &dspy::hll_sketch_serialize_updatable)
     .def("to_string", (std::string (HllSketch<>::*)(bool,bool,bool,bool) const) &HllSketch<>::to_string,
          py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
     .def("__str__", (std::string (HllSketch<>::*)(bool,bool,bool,bool) const) &HllSketch<>::to_string,
@@ -103,9 +103,9 @@ void init_hll(py::module &m) {
 
   py::class_<HllUnion<>>(m, "hll_union")
     .def(py::init<int>(), py::arg("lg_max_k"))
-    .def_static("deserialize", &dspy::HllUnion_deserialize)
-    .def("serialize_compact", &dspy::HllUnion_serializeCompact)
-    .def("serialize_updatable", &dspy::HllUnion_serializeUpdatable)
+    .def_static("deserialize", &dspy::hll_union_deserialize)
+    .def("serialize_compact", &dspy::hll_union_serialize_compact)
+    .def("serialize_updatable", &dspy::hll_union_serialize_updatable)
     .def("to_string", (std::string (HllUnion<>::*)(bool,bool,bool,bool) const) &HllUnion<>::to_string,
          py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
     .def("__str__", (std::string (HllUnion<>::*)(bool,bool,bool,bool) const) &HllUnion<>::to_string,

--- a/python/src/kll_wrapper.cpp
+++ b/python/src/kll_wrapper.cpp
@@ -29,13 +29,13 @@ namespace datasketches {
 namespace python {
 
 template<typename T>
-kll_sketch<T> KllSketch_deserialize(py::bytes skBytes) {
+kll_sketch<T> kll_sketch_deserialize(py::bytes skBytes) {
   std::string skStr = skBytes; // implicit cast  
   return kll_sketch<T>::deserialize(skStr.c_str(), skStr.length());
 }
 
 template<typename T>
-py::object KllSketch_serialize(const kll_sketch<T>& sk) {
+py::object kll_sketch_serialize(const kll_sketch<T>& sk) {
   auto serResult = sk.serialize();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
@@ -43,12 +43,12 @@ py::object KllSketch_serialize(const kll_sketch<T>& sk) {
 // maybe possible to disambiguate the static vs method rank error calls, but
 // this is easier for now
 template<typename T>
-double KllSketch_generalNormalizedRankError(uint16_t k, bool pmf) {
+double kll_sketch_generic_normalized_rank_error(uint16_t k, bool pmf) {
   return kll_sketch<T>::get_normalized_rank_error(k, pmf);
 }
 
 template<typename T>
-py::list KllSketch_getQuantiles(const kll_sketch<T>& sk,
+py::list kll_sketch_get_quantiles(const kll_sketch<T>& sk,
                                 std::vector<double>& fractions) {
   size_t nQuantiles = fractions.size();
   std::unique_ptr<T[]> result = sk.get_quantiles(&fractions[0], nQuantiles);
@@ -63,7 +63,7 @@ py::list KllSketch_getQuantiles(const kll_sketch<T>& sk,
 }
 
 template<typename T>
-py::list KllSketch_getPMF(const kll_sketch<T>& sk,
+py::list kll_sketch_get_pmf(const kll_sketch<T>& sk,
                           std::vector<T>& split_points) {
   size_t nPoints = split_points.size();
   std::unique_ptr<double[]> result = sk.get_PMF(&split_points[0], nPoints);
@@ -77,7 +77,7 @@ py::list KllSketch_getPMF(const kll_sketch<T>& sk,
 }
 
 template<typename T>
-py::list KllSketch_getCDF(const kll_sketch<T>& sk,
+py::list kll_sketch_get_cdf(const kll_sketch<T>& sk,
                           std::vector<T>& split_points) {
   size_t nPoints = split_points.size();
   std::unique_ptr<double[]> result = sk.get_CDF(&split_points[0], nPoints);
@@ -91,11 +91,8 @@ py::list KllSketch_getCDF(const kll_sketch<T>& sk,
 }
 
 template<typename T>
-//std::string KllSketch_toString(const kll_sketch<T>& sk, bool print_levels, bool print_items) {
-std::string KllSketch_toString(const kll_sketch<T>& sk) {
+std::string kll_sketch_to_string(const kll_sketch<T>& sk) {
   std::ostringstream ss;
-  // kll_sketch::toS_straem class does not currently pay attention to the flags
-  //sk.to_stream(ss, print_levels, print_items);
   sk.to_stream(ss);
   return ss.str();
 }
@@ -114,7 +111,7 @@ void bind_kll_sketch(py::module &m, const char* name) {
     .def(py::init<const kll_sketch<T>&>())
     .def("update", &kll_sketch<T>::update, py::arg("item"))
     .def("merge", &kll_sketch<T>::merge, py::arg("sketch"))
-    .def("__str__", &dspy::KllSketch_toString<T>)
+    .def("__str__", &dspy::kll_sketch_to_string<T>)
     .def("is_empty", &kll_sketch<T>::is_empty)
     .def("get_n", &kll_sketch<T>::get_n)
     .def("get_num_retained", &kll_sketch<T>::get_num_retained)
@@ -122,20 +119,18 @@ void bind_kll_sketch(py::module &m, const char* name) {
     .def("get_min_value", &kll_sketch<T>::get_min_value)
     .def("get_max_value", &kll_sketch<T>::get_max_value)
     .def("get_quantile", &kll_sketch<T>::get_quantile, py::arg("fraction"))
-    .def("get_quantiles", &dspy::KllSketch_getQuantiles<T>, py::arg("fractions"))
+    .def("get_quantiles", &dspy::kll_sketch_get_quantiles<T>, py::arg("fractions"))
     .def("get_rank", &kll_sketch<T>::get_rank, py::arg("value"))
-    .def("get_pmf", &dspy::KllSketch_getPMF<T>, py::arg("split_points"))
-    .def("get_cdf", &dspy::KllSketch_getCDF<T>, py::arg("split_points"))
+    .def("get_pmf", &dspy::kll_sketch_get_pmf<T>, py::arg("split_points"))
+    .def("get_cdf", &dspy::kll_sketch_get_cdf<T>, py::arg("split_points"))
     .def("normalized_rank_error", (double (kll_sketch<T>::*)(bool) const) &kll_sketch<T>::get_normalized_rank_error,
          py::arg("as_pmf"))
-    .def_static("get_normalized_rank_error", &dspy::KllSketch_generalNormalizedRankError<T>,
+    .def_static("get_normalized_rank_error", &dspy::kll_sketch_generic_normalized_rank_error<T>,
          py::arg("k"), py::arg("as_pmf"))
     // can't yet get this one to work
     //.def("get_serialized_size_bytes", &kll_sketch<T>::get_serialized_size_bytes)
-    // this doesn't seem to be defined in the class
-    //.def_static("get_max_serialized_size_bytes", &kll_sketch<T>::get_max_serialized_size_bytes)
-    .def("serialize", &dspy::KllSketch_serialize<T>)
-    .def_static("deserialize", &dspy::KllSketch_deserialize<T>)
+    .def("serialize", &dspy::kll_sketch_serialize<T>)
+    .def_static("deserialize", &dspy::kll_sketch_deserialize<T>)
     ;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,11 @@
 # http://www.benjack.io/2018/02/02/python-cpp-revisited.html
 
 import os
-#import re
 import sys
 import sysconfig
 import platform
 import subprocess
 
-from distutils.version import LooseVersion
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
@@ -20,7 +18,7 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError(
                 "CMake >= 3.12 must be installed to build the following extensions: " +
@@ -67,19 +65,18 @@ class CMakeBuild(build_ext):
 
 setup(
     name='datasketches',
-    version='0.0.1',
-    author='Jon Malkin',
-    author_email='jon.malkin@yahoo.com',
+    use_scm_version=True,
+    author='Datasketches Developers',
+    author_email='dev@datasketches.apache.org',
     description='A wrapper for the C++ Datasketches library',
-    long_description='',
-    # tell setuptools to look for any packages under 'python/src'
-    packages=find_packages('python/src'),
-    # tell setuptools that all packages will be under the 'python/src' directory
-    # and nowhere else
-    package_dir={'':'python/src'},
-    # likely need to add all source paths for proper sdist packages
+    license='Apache License 2.0',
+    url='http://datasketches.apache.org',
+    long_description=open('python/README.md').read(),
+    packages=find_packages('python'), # python pacakges only in this dir
+    package_dir={'':'python'},
+    # may need to add all source paths for sdist packages w/o MANIFEST.in
     ext_modules=[CMakeExtension('datasketches')],
-    # add custom build_ext command
     cmdclass={'build_ext': CMakeBuild},
+    setup_requires=["setuptools_scm"],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ class CMakeBuild(build_ext):
 
 setup(
     name='datasketches',
-    use_scm_version=True,
+    #use_scm_version=True,
+    version='0.0.1',
     author='Datasketches Developers',
     author_email='dev@datasketches.apache.org',
     description='A wrapper for the C++ Datasketches library',


### PR DESCRIPTION
I believe this gets everything ready to create a source distribution (sdist) tarball for python. But I'm not sure if there's an issue packaging the BSD-licensed pybind11 in the tarball with our code?

We point to it as a submodule in git, which they suggest doing in their own cmake example, and they even say to use --recursive when cloning. But that's not necessarily the same as distributing it within our tarball.

Since the current code doesn't work properly to create an artifact that can be pushed to python's package repository (pypi) I'm ok with it. But committing this change would make it much easier to upload something to there. So I'll suggest hold off on actually merging until we get feedback on whether this approach is valid.