### PR TITLE
change HLL public API from CamelCase to lower_with_underscore

### DIFF
--- a/hll/include/AuxHashMap.hpp
+++ b/hll/include/AuxHashMap.hpp
@@ -51,7 +51,7 @@ class AuxHashMap final {
     int getAuxCount() const;
     int* getAuxIntArr();
     int getLgAuxArrInts() const;
-    PairIterator_with_deleter<A> getIterator() const;
+    pair_iterator_with_deleter<A> getIterator() const;
 
     void mustAdd(int slotNo, int value);
     int mustFindValueFor(int slotNo);

--- a/hll/include/CouponHashSet-internal.hpp
+++ b/hll/include/CouponHashSet-internal.hpp
@@ -32,7 +32,7 @@ template<typename A>
 static int find(const int* array, const int lgArrInts, const int coupon);
 
 template<typename A>
-CouponHashSet<A>::CouponHashSet(const int lgConfigK, const TgtHllType tgtHllType)
+CouponHashSet<A>::CouponHashSet(const int lgConfigK, const target_hll_type tgtHllType)
   : CouponList<A>(lgConfigK, tgtHllType, CurMode::SET)
 {
   if (lgConfigK <= 7) {
@@ -46,7 +46,7 @@ CouponHashSet<A>::CouponHashSet(const CouponHashSet<A>& that)
   : CouponList<A>(that) {}
 
 template<typename A>
-CouponHashSet<A>::CouponHashSet(const CouponHashSet<A>& that, const TgtHllType tgtHllType)
+CouponHashSet<A>::CouponHashSet(const CouponHashSet<A>& that, const target_hll_type tgtHllType)
   : CouponList<A>(that, tgtHllType) {}
 
 template<typename A>
@@ -83,7 +83,7 @@ CouponHashSet<A>* CouponHashSet<A>::newSet(const void* bytes, size_t len) {
     throw std::invalid_argument("Calling set construtor with non-set mode data");
   }
 
-  const TgtHllType tgtHllType = HllSketchImpl<A>::extractTgtHllType(data[HllUtil<A>::MODE_BYTE]);
+  const target_hll_type tgtHllType = HllSketchImpl<A>::extractTgtHllType(data[HllUtil<A>::MODE_BYTE]);
 
   const int lgK = data[HllUtil<A>::LG_K_BYTE];
   if (lgK <= 7) {
@@ -154,7 +154,7 @@ CouponHashSet<A>* CouponHashSet<A>::newSet(std::istream& is) {
     throw std::invalid_argument("Calling set construtor with non-set mode data");
   }
 
-  TgtHllType tgtHllType = HllSketchImpl<A>::extractTgtHllType(listHeader[HllUtil<A>::MODE_BYTE]);
+  target_hll_type tgtHllType = HllSketchImpl<A>::extractTgtHllType(listHeader[HllUtil<A>::MODE_BYTE]);
 
   const int lgK = listHeader[HllUtil<A>::LG_K_BYTE];
   if (lgK <= 7) {
@@ -202,7 +202,7 @@ CouponHashSet<A>* CouponHashSet<A>::copy() const {
 }
 
 template<typename A>
-CouponHashSet<A>* CouponHashSet<A>::copyAs(const TgtHllType tgtHllType) const {
+CouponHashSet<A>* CouponHashSet<A>::copyAs(const target_hll_type tgtHllType) const {
   return new (chsAlloc().allocate(1)) CouponHashSet<A>(*this, tgtHllType);
 }
 

--- a/hll/include/CouponHashSet-internal.hpp
+++ b/hll/include/CouponHashSet-internal.hpp
@@ -33,7 +33,7 @@ static int find(const int* array, const int lgArrInts, const int coupon);
 
 template<typename A>
 CouponHashSet<A>::CouponHashSet(const int lgConfigK, const target_hll_type tgtHllType)
-  : CouponList<A>(lgConfigK, tgtHllType, CurMode::SET)
+  : CouponList<A>(lgConfigK, tgtHllType, hll_mode::SET)
 {
   if (lgConfigK <= 7) {
     throw std::invalid_argument("CouponHashSet must be initialized with lgConfigK > 7. Found: "
@@ -78,8 +78,8 @@ CouponHashSet<A>* CouponHashSet<A>::newSet(const void* bytes, size_t len) {
     throw std::invalid_argument("Input stream is not an HLL sketch");
   }
 
-  const CurMode curMode = HllSketchImpl<A>::extractCurMode(data[HllUtil<A>::MODE_BYTE]);
-  if (curMode != SET) {
+  const hll_mode mode = HllSketchImpl<A>::extractCurMode(data[HllUtil<A>::MODE_BYTE]);
+  if (mode != SET) {
     throw std::invalid_argument("Calling set construtor with non-set mode data");
   }
 
@@ -149,8 +149,8 @@ CouponHashSet<A>* CouponHashSet<A>::newSet(std::istream& is) {
     throw std::invalid_argument("Input stream is not an HLL sketch");
   }
 
-  CurMode curMode = HllSketchImpl<A>::extractCurMode(listHeader[HllUtil<A>::MODE_BYTE]);
-  if (curMode != SET) {
+  hll_mode mode = HllSketchImpl<A>::extractCurMode(listHeader[HllUtil<A>::MODE_BYTE]);
+  if (mode != SET) {
     throw std::invalid_argument("Calling set construtor with non-set mode data");
   }
 

--- a/hll/include/CouponHashSet.hpp
+++ b/hll/include/CouponHashSet.hpp
@@ -29,8 +29,8 @@ class CouponHashSet : public CouponList<A> {
   public:
     static CouponHashSet* newSet(const void* bytes, size_t len);
     static CouponHashSet* newSet(std::istream& is);
-    explicit CouponHashSet(int lgConfigK, TgtHllType tgtHllType);
-    explicit CouponHashSet(const CouponHashSet& that, TgtHllType tgtHllType);
+    explicit CouponHashSet(int lgConfigK, target_hll_type tgtHllType);
+    explicit CouponHashSet(const CouponHashSet& that, target_hll_type tgtHllType);
     explicit CouponHashSet(const CouponHashSet& that);
 
     virtual ~CouponHashSet();
@@ -39,7 +39,7 @@ class CouponHashSet : public CouponList<A> {
   protected:
     
     virtual CouponHashSet* copy() const;
-    virtual CouponHashSet* copyAs(TgtHllType tgtHllType) const;
+    virtual CouponHashSet* copyAs(target_hll_type tgtHllType) const;
 
     virtual HllSketchImpl<A>* couponUpdate(int coupon);
 

--- a/hll/include/CouponList-internal.hpp
+++ b/hll/include/CouponList-internal.hpp
@@ -33,7 +33,7 @@
 namespace datasketches {
 
 template<typename A>
-CouponList<A>::CouponList(const int lgConfigK, const TgtHllType tgtHllType, const CurMode curMode)
+CouponList<A>::CouponList(const int lgConfigK, const target_hll_type tgtHllType, const CurMode curMode)
   : HllSketchImpl<A>(lgConfigK, tgtHllType, curMode, false) {
     if (curMode == CurMode::LIST) {
       lgCouponArrInts = HllUtil<A>::LG_INIT_LIST_SIZE;
@@ -63,7 +63,7 @@ CouponList<A>::CouponList(const CouponList& that)
 }
 
 template<typename A>
-CouponList<A>::CouponList(const CouponList& that, const TgtHllType tgtHllType)
+CouponList<A>::CouponList(const CouponList& that, const target_hll_type tgtHllType)
   : HllSketchImpl<A>(that.lgConfigK, tgtHllType, that.curMode, false),
     lgCouponArrInts(that.lgCouponArrInts),
     couponCount(that.couponCount),
@@ -96,7 +96,7 @@ CouponList<A>* CouponList<A>::copy() const {
 }
 
 template<typename A>
-CouponList<A>* CouponList<A>::copyAs(const TgtHllType tgtHllType) const {
+CouponList<A>* CouponList<A>::copyAs(target_hll_type tgtHllType) const {
   return new (clAlloc().allocate(1)) CouponList<A>(*this, tgtHllType);
 }
 
@@ -122,7 +122,7 @@ CouponList<A>* CouponList<A>::newList(const void* bytes, size_t len) {
     throw std::invalid_argument("Calling set construtor with non-list mode data");
   }
 
-  TgtHllType tgtHllType = HllSketchImpl<A>::extractTgtHllType(data[HllUtil<A>::MODE_BYTE]);
+  target_hll_type tgtHllType = HllSketchImpl<A>::extractTgtHllType(data[HllUtil<A>::MODE_BYTE]);
 
   const int lgK = data[HllUtil<A>::LG_K_BYTE];
   const bool compact = ((data[HllUtil<A>::FLAGS_BYTE] & HllUtil<A>::COMPACT_FLAG_MASK) ? true : false);
@@ -169,7 +169,7 @@ CouponList<A>* CouponList<A>::newList(std::istream& is) {
     throw std::invalid_argument("Calling list construtor with non-list mode data");
   }
 
-  const TgtHllType tgtHllType = HllSketchImpl<A>::extractTgtHllType(listHeader[HllUtil<A>::MODE_BYTE]);
+  const target_hll_type tgtHllType = HllSketchImpl<A>::extractTgtHllType(listHeader[HllUtil<A>::MODE_BYTE]);
 
   const int lgK = (int) listHeader[HllUtil<A>::LG_K_BYTE];
   const bool compact = ((listHeader[HllUtil<A>::FLAGS_BYTE] & HllUtil<A>::COMPACT_FLAG_MASK) ? true : false);
@@ -225,7 +225,7 @@ std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
       break;
     }
     case 1: { // src updatable, dst compact
-      PairIterator_with_deleter<A> itr = getIterator();
+      pair_iterator_with_deleter<A> itr = getIterator();
       bytes += getMemDataStart(); // reusing ponter for incremental writes
       while (itr->nextValid()) {
         const int pairValue = itr->getPair();
@@ -283,7 +283,7 @@ void CouponList<A>::serialize(std::ostream& os, const bool compact) const {
       break;
     }
     case 1: { // src updatable, dst compact
-      PairIterator_with_deleter<A> itr = getIterator();
+      pair_iterator_with_deleter<A> itr = getIterator();
       while (itr->nextValid()) {
         const int pairValue = itr->getPair();
         os.write((char*)&pairValue, sizeof(pairValue));
@@ -401,10 +401,10 @@ int* CouponList<A>::getCouponIntArr() const {
 }
 
 template<typename A>
-PairIterator_with_deleter<A> CouponList<A>::getIterator() const {
+pair_iterator_with_deleter<A> CouponList<A>::getIterator() const {
   typedef typename std::allocator_traits<A>::template rebind_alloc<IntArrayPairIterator<A>> iapiAlloc;
   IntArrayPairIterator<A>* itr = new (iapiAlloc().allocate(1)) IntArrayPairIterator<A>(couponIntArr, 1 << lgCouponArrInts, this->lgConfigK);
-  return PairIterator_with_deleter<A>(
+  return pair_iterator_with_deleter<A>(
     itr,
     [](PairIterator<A>* ptr) {
       IntArrayPairIterator<A>* iapi = static_cast<IntArrayPairIterator<A>*>(ptr);

--- a/hll/include/CouponList.hpp
+++ b/hll/include/CouponList.hpp
@@ -31,9 +31,9 @@ class HllSketchImplFactory;
 template<typename A = std::allocator<char>>
 class CouponList : public HllSketchImpl<A> {
   public:
-    explicit CouponList(int lgConfigK, TgtHllType tgtHllType, CurMode curMode);
+    explicit CouponList(int lgConfigK, target_hll_type tgtHllType, CurMode curMode);
     explicit CouponList(const CouponList& that);
-    explicit CouponList(const CouponList& that, TgtHllType tgtHllType);
+    explicit CouponList(const CouponList& that, target_hll_type tgtHllType);
 
     static CouponList* newList(const void* bytes, size_t len);
     static CouponList* newList(std::istream& is);
@@ -44,7 +44,7 @@ class CouponList : public HllSketchImpl<A> {
     virtual std::function<void(HllSketchImpl<A>*)> get_deleter() const;
 
     virtual CouponList* copy() const;
-    virtual CouponList* copyAs(TgtHllType tgtHllType) const;
+    virtual CouponList* copyAs(target_hll_type tgtHllType) const;
 
     virtual HllSketchImpl<A>* couponUpdate(int coupon);
 
@@ -55,7 +55,7 @@ class CouponList : public HllSketchImpl<A> {
 
     virtual bool isEmpty() const;
     virtual int getCouponCount() const;
-    virtual PairIterator_with_deleter<A> getIterator() const;
+    virtual pair_iterator_with_deleter<A> getIterator() const;
 
   protected:
     typedef typename std::allocator_traits<A>::template rebind_alloc<CouponList<A>> clAlloc;

--- a/hll/include/CouponList.hpp
+++ b/hll/include/CouponList.hpp
@@ -31,7 +31,7 @@ class HllSketchImplFactory;
 template<typename A = std::allocator<char>>
 class CouponList : public HllSketchImpl<A> {
   public:
-    explicit CouponList(int lgConfigK, target_hll_type tgtHllType, CurMode curMode);
+    explicit CouponList(int lgConfigK, target_hll_type tgtHllType, hll_mode mode);
     explicit CouponList(const CouponList& that);
     explicit CouponList(const CouponList& that, target_hll_type tgtHllType);
 

--- a/hll/include/Hll4Array-internal.hpp
+++ b/hll/include/Hll4Array-internal.hpp
@@ -51,7 +51,7 @@ int Hll4Iterator<A>::value() {
 
 template<typename A>
 Hll4Array<A>::Hll4Array(const int lgConfigK, const bool startFullSize) :
-    HllArray<A>(lgConfigK, TgtHllType::HLL_4, startFullSize) {
+    HllArray<A>(lgConfigK, target_hll_type::HLL_4, startFullSize) {
   const int numBytes = this->hll4ArrBytes(lgConfigK);
   typedef typename std::allocator_traits<A>::template rebind_alloc<uint8_t> uint8Alloc;
   this->hllByteArr = uint8Alloc().allocate(numBytes);
@@ -97,10 +97,10 @@ Hll4Array<A>* Hll4Array<A>::copy() const {
 }
 
 template<typename A>
-PairIterator_with_deleter<A> Hll4Array<A>::getIterator() const {
+pair_iterator_with_deleter<A> Hll4Array<A>::getIterator() const {
   typedef typename std::allocator_traits<A>::template rebind_alloc<Hll4Iterator<A>> itrAlloc;
   Hll4Iterator<A>* itr = new (itrAlloc().allocate(1)) Hll4Iterator<A>(*this, 1 << this->lgConfigK);
-  return PairIterator_with_deleter<A>(
+  return pair_iterator_with_deleter<A>(
     itr,
     [](PairIterator<A>* ptr) {
       Hll4Iterator<A>* hll = static_cast<Hll4Iterator<A>*>(ptr);
@@ -111,7 +111,7 @@ PairIterator_with_deleter<A> Hll4Array<A>::getIterator() const {
 }
 
 template<typename A>
-PairIterator_with_deleter<A> Hll4Array<A>::getAuxIterator() const {
+pair_iterator_with_deleter<A> Hll4Array<A>::getAuxIterator() const {
   if (auxHashMap != nullptr) {
     return auxHashMap->getIterator();
   }
@@ -312,7 +312,7 @@ void Hll4Array<A>::shiftToBiggerCurMin() {
     int oldActualVal;
     int newShiftedVal;
 
-    PairIterator_with_deleter<A> itr = auxHashMap->getIterator();
+    pair_iterator_with_deleter<A> itr = auxHashMap->getIterator();
     while (itr->nextValid()) {
       slotNum = itr->getKey() & configKmask;
       oldActualVal = itr->getValue();

--- a/hll/include/Hll4Array.hpp
+++ b/hll/include/Hll4Array.hpp
@@ -40,8 +40,8 @@ class Hll4Array final : public HllArray<A> {
 
     virtual Hll4Array* copy() const;
 
-    virtual PairIterator_with_deleter<A> getIterator() const;
-    virtual PairIterator_with_deleter<A> getAuxIterator() const;
+    virtual pair_iterator_with_deleter<A> getIterator() const;
+    virtual pair_iterator_with_deleter<A> getAuxIterator() const;
 
     virtual int getSlot(int slotNo) const final;
     virtual void putSlot(int slotNo, int value) final;

--- a/hll/include/Hll6Array-internal.hpp
+++ b/hll/include/Hll6Array-internal.hpp
@@ -48,7 +48,7 @@ int Hll6Iterator<A>::value() {
 
 template<typename A>
 Hll6Array<A>::Hll6Array(const int lgConfigK, const bool startFullSize) :
-    HllArray<A>(lgConfigK, TgtHllType::HLL_6, startFullSize) {
+    HllArray<A>(lgConfigK, target_hll_type::HLL_6, startFullSize) {
   const int numBytes = this->hll6ArrBytes(lgConfigK);
   typedef typename std::allocator_traits<A>::template rebind_alloc<uint8_t> uint8Alloc;
   this->hllByteArr = uint8Alloc().allocate(numBytes);
@@ -84,10 +84,10 @@ Hll6Array<A>* Hll6Array<A>::copy() const {
 }
 
 template<typename A>
-PairIterator_with_deleter<A> Hll6Array<A>::getIterator() const {
+pair_iterator_with_deleter<A> Hll6Array<A>::getIterator() const {
   typedef typename std::allocator_traits<A>::template rebind_alloc<Hll6Iterator<A>> itrAlloc;
   Hll6Iterator<A>* itr = new (itrAlloc().allocate(1)) Hll6Iterator<A>(*this, 1 << this->lgConfigK);
-  return PairIterator_with_deleter<A>(
+  return pair_iterator_with_deleter<A>(
     itr,
     [](PairIterator<A>* ptr) {
       Hll6Iterator<A>* hll = static_cast<Hll6Iterator<A>*>(ptr);

--- a/hll/include/Hll6Array.hpp
+++ b/hll/include/Hll6Array.hpp
@@ -39,7 +39,7 @@ class Hll6Array final : public HllArray<A> {
 
     virtual Hll6Array* copy() const;
 
-    virtual PairIterator_with_deleter<A> getIterator() const;
+    virtual pair_iterator_with_deleter<A> getIterator() const;
 
     virtual int getSlot(int slotNo) const final;
     virtual void putSlot(int slotNo, int value) final;

--- a/hll/include/Hll8Array-internal.hpp
+++ b/hll/include/Hll8Array-internal.hpp
@@ -42,7 +42,7 @@ int Hll8Iterator<A>::value() {
 
 template<typename A>
 Hll8Array<A>::Hll8Array(const int lgConfigK, const bool startFullSize) :
-    HllArray<A>(lgConfigK, TgtHllType::HLL_8, startFullSize) {
+    HllArray<A>(lgConfigK, target_hll_type::HLL_8, startFullSize) {
   const int numBytes = this->hll8ArrBytes(lgConfigK);
   typedef typename std::allocator_traits<A>::template rebind_alloc<uint8_t> uint8Alloc;
   this->hllByteArr = uint8Alloc().allocate(numBytes);
@@ -78,10 +78,10 @@ Hll8Array<A>* Hll8Array<A>::copy() const {
 }
 
 template<typename A>
-PairIterator_with_deleter<A> Hll8Array<A>::getIterator() const {
+pair_iterator_with_deleter<A> Hll8Array<A>::getIterator() const {
   typedef typename std::allocator_traits<A>::template rebind_alloc<Hll8Iterator<A>> itrAlloc;
   Hll8Iterator<A>* itr = new (itrAlloc().allocate(1)) Hll8Iterator<A>(*this, 1 << this->lgConfigK);
-  return PairIterator_with_deleter<A>(
+  return pair_iterator_with_deleter<A>(
     itr,
     [](PairIterator<A>* ptr) {
       Hll8Iterator<A>* hll = static_cast<Hll8Iterator<A>*>(ptr);

--- a/hll/include/Hll8Array.hpp
+++ b/hll/include/Hll8Array.hpp
@@ -39,7 +39,7 @@ class Hll8Array final : public HllArray<A> {
 
     virtual Hll8Array<A>* copy() const;
 
-    virtual PairIterator_with_deleter<A> getIterator() const;
+    virtual pair_iterator_with_deleter<A> getIterator() const;
 
     virtual int getSlot(int slotNo) const final;
     virtual void putSlot(int slotNo, int value) final;

--- a/hll/include/HllArray-internal.hpp
+++ b/hll/include/HllArray-internal.hpp
@@ -36,7 +36,7 @@ namespace datasketches {
 
 template<typename A>
 HllArray<A>::HllArray(const int lgConfigK, const target_hll_type tgtHllType, bool startFullSize)
-  : HllSketchImpl<A>(lgConfigK, tgtHllType, CurMode::HLL, startFullSize) {
+  : HllSketchImpl<A>(lgConfigK, tgtHllType, hll_mode::HLL, startFullSize) {
   hipAccum = 0.0;
   kxq0 = 1 << lgConfigK;
   kxq1 = 0.0;
@@ -48,7 +48,7 @@ HllArray<A>::HllArray(const int lgConfigK, const target_hll_type tgtHllType, boo
 
 template<typename A>
 HllArray<A>::HllArray(const HllArray<A>& that)
-  : HllSketchImpl<A>(that.lgConfigK, that.tgtHllType, CurMode::HLL, that.startFullSize) {
+  : HllSketchImpl<A>(that.lgConfigK, that.tgtHllType, hll_mode::HLL, that.startFullSize) {
   hipAccum = that.getHipAccum();
   kxq0 = that.getKxQ0();
   kxq1 = that.getKxQ1();
@@ -110,8 +110,8 @@ HllArray<A>* HllArray<A>::newHll(const void* bytes, size_t len) {
     throw std::invalid_argument("Input array is not an HLL sketch");
   }
 
-  const CurMode curMode = HllSketchImpl<A>::extractCurMode(data[HllUtil<A>::MODE_BYTE]);
-  if (curMode != HLL) {
+  const hll_mode mode = HllSketchImpl<A>::extractCurMode(data[HllUtil<A>::MODE_BYTE]);
+  if (mode != HLL) {
     throw std::invalid_argument("Calling HLL array construtor with non-HLL mode data");
   }
 
@@ -176,8 +176,8 @@ HllArray<A>* HllArray<A>::newHll(std::istream& is) {
     throw std::invalid_argument("Input stream is not an HLL sketch");
   }
 
-  CurMode curMode = HllSketchImpl<A>::extractCurMode(listHeader[HllUtil<A>::MODE_BYTE]);
-  if (curMode != HLL) {
+  hll_mode mode = HllSketchImpl<A>::extractCurMode(listHeader[HllUtil<A>::MODE_BYTE]);
+  if (mode != HLL) {
     throw std::invalid_argument("Calling HLL construtor with non-HLL mode data");
   }
 

--- a/hll/include/HllArray-internal.hpp
+++ b/hll/include/HllArray-internal.hpp
@@ -35,7 +35,7 @@
 namespace datasketches {
 
 template<typename A>
-HllArray<A>::HllArray(const int lgConfigK, const TgtHllType tgtHllType, bool startFullSize)
+HllArray<A>::HllArray(const int lgConfigK, const target_hll_type tgtHllType, bool startFullSize)
   : HllSketchImpl<A>(lgConfigK, tgtHllType, CurMode::HLL, startFullSize) {
   hipAccum = 0.0;
   kxq0 = 1 << lgConfigK;
@@ -67,9 +67,9 @@ template<typename A>
 HllArray<A>::~HllArray() {
   // need to determine number of bytes to deallocate
   int hllArrBytes = 0;
-  if (this->tgtHllType == TgtHllType::HLL_4) {
+  if (this->tgtHllType == target_hll_type::HLL_4) {
     hllArrBytes = hll4ArrBytes(this->lgConfigK);
-  } else if (this->tgtHllType == TgtHllType::HLL_6) {
+  } else if (this->tgtHllType == target_hll_type::HLL_6) {
     hllArrBytes = hll6ArrBytes(this->lgConfigK);
   } else { // tgtHllType == HLL_8
     hllArrBytes = hll8ArrBytes(this->lgConfigK);
@@ -80,13 +80,13 @@ HllArray<A>::~HllArray() {
 }
 
 template<typename A>
-HllArray<A>* HllArray<A>::copyAs(const TgtHllType tgtHllType) const {
+HllArray<A>* HllArray<A>::copyAs(const target_hll_type tgtHllType) const {
   if (tgtHllType == this->getTgtHllType()) {
     return static_cast<HllArray*>(copy());
   }
-  if (tgtHllType == TgtHllType::HLL_4) {
+  if (tgtHllType == target_hll_type::HLL_4) {
     return HllSketchImplFactory<A>::convertToHll4(*this);
-  } else if (tgtHllType == TgtHllType::HLL_6) {
+  } else if (tgtHllType == target_hll_type::HLL_6) {
     return HllSketchImplFactory<A>::convertToHll6(*this);
   } else { // tgtHllType == HLL_8
     return HllSketchImplFactory<A>::convertToHll8(*this);
@@ -115,7 +115,7 @@ HllArray<A>* HllArray<A>::newHll(const void* bytes, size_t len) {
     throw std::invalid_argument("Calling HLL array construtor with non-HLL mode data");
   }
 
-  const TgtHllType tgtHllType = HllSketchImpl<A>::extractTgtHllType(data[HllUtil<A>::MODE_BYTE]);
+  const target_hll_type tgtHllType = HllSketchImpl<A>::extractTgtHllType(data[HllUtil<A>::MODE_BYTE]);
   const bool oooFlag = ((data[HllUtil<A>::FLAGS_BYTE] & HllUtil<A>::OUT_OF_ORDER_FLAG_MASK) ? true : false);
   const bool comapctFlag = ((data[HllUtil<A>::FLAGS_BYTE] & HllUtil<A>::COMPACT_FLAG_MASK) ? true : false);
   const bool startFullSizeFlag = ((data[HllUtil<A>::FLAGS_BYTE] & HllUtil<A>::FULL_SIZE_FLAG_MASK) ? true : false);
@@ -181,7 +181,7 @@ HllArray<A>* HllArray<A>::newHll(std::istream& is) {
     throw std::invalid_argument("Calling HLL construtor with non-HLL mode data");
   }
 
-  const TgtHllType tgtHllType = HllSketchImpl<A>::extractTgtHllType(listHeader[HllUtil<A>::MODE_BYTE]);
+  const target_hll_type tgtHllType = HllSketchImpl<A>::extractTgtHllType(listHeader[HllUtil<A>::MODE_BYTE]);
   const bool oooFlag = ((listHeader[HllUtil<A>::FLAGS_BYTE] & HllUtil<A>::OUT_OF_ORDER_FLAG_MASK) ? true : false);
   const bool comapctFlag = ((listHeader[HllUtil<A>::FLAGS_BYTE] & HllUtil<A>::COMPACT_FLAG_MASK) ? true : false);
   const bool startFullSizeFlag = ((listHeader[HllUtil<A>::FLAGS_BYTE] & HllUtil<A>::FULL_SIZE_FLAG_MASK) ? true : false);
@@ -254,7 +254,7 @@ std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
     bytes += getMemDataStart() + hllByteArrBytes; // start of auxHashMap
     if (auxHashMap != nullptr) {
       if (compact) {
-        PairIterator_with_deleter<A> itr = auxHashMap->getIterator();
+        pair_iterator_with_deleter<A> itr = auxHashMap->getIterator();
         while (itr->nextValid()) {
           const int pairValue = itr->getPair();
           std::memcpy(bytes, &pairValue, sizeof(pairValue));
@@ -315,8 +315,7 @@ void HllArray<A>::serialize(std::ostream& os, const bool compact) const {
   if (this->tgtHllType == HLL_4) {
     if (auxHashMap != nullptr) {
       if (compact) {
-        //std::unique_ptr<PairIterator<A>> itr = auxHashMap->getIterator();
-        PairIterator_with_deleter<A> itr = auxHashMap->getIterator();
+        pair_iterator_with_deleter<A> itr = auxHashMap->getIterator();
         while (itr->nextValid()) {
           const int pairValue = itr->getPair();
           os.write((char*)&pairValue, sizeof(pairValue));
@@ -541,7 +540,7 @@ bool HllArray<A>::isOutOfOrderFlag() const {
 }
 
 template<typename A>
-int HllArray<A>::hllArrBytes(TgtHllType tgtHllType, int lgConfigK) {
+int HllArray<A>::hllArrBytes(target_hll_type tgtHllType, int lgConfigK) {
   switch (tgtHllType) {
   case HLL_4:
     return hll4ArrBytes(lgConfigK);
@@ -593,7 +592,7 @@ int HllArray<A>::getPreInts() const {
 }
 
 template<typename A>
-PairIterator_with_deleter<A> HllArray<A>::getAuxIterator() const {
+pair_iterator_with_deleter<A> HllArray<A>::getAuxIterator() const {
   return nullptr;
 }
 

--- a/hll/include/HllArray.hpp
+++ b/hll/include/HllArray.hpp
@@ -32,7 +32,7 @@ class AuxHashMap;
 template<typename A = std::allocator<char>>
 class HllArray : public HllSketchImpl<A> {
   public:
-    explicit HllArray(int lgConfigK, TgtHllType tgtHllType, bool startFullSize);
+    explicit HllArray(int lgConfigK, target_hll_type tgtHllType, bool startFullSize);
     explicit HllArray(const HllArray<A>& that);
 
     static HllArray* newHll(const void* bytes, size_t len);
@@ -45,7 +45,7 @@ class HllArray : public HllSketchImpl<A> {
     virtual std::function<void(HllSketchImpl<A>*)> get_deleter() const = 0;
 
     virtual HllArray* copy() const = 0;
-    virtual HllArray* copyAs(TgtHllType tgtHllType) const;
+    virtual HllArray* copyAs(target_hll_type tgtHllType) const;
 
     virtual HllSketchImpl<A>* couponUpdate(int coupon) = 0;
 
@@ -64,8 +64,8 @@ class HllArray : public HllSketchImpl<A> {
 
     virtual int getHllByteArrBytes() const = 0;
 
-    virtual PairIterator_with_deleter<A> getIterator() const = 0;
-    virtual PairIterator_with_deleter<A> getAuxIterator() const;
+    virtual pair_iterator_with_deleter<A> getIterator() const = 0;
+    virtual pair_iterator_with_deleter<A> getAuxIterator() const;
 
     virtual int getUpdatableSerializationBytes() const;
     virtual int getCompactSerializationBytes() const;
@@ -91,7 +91,7 @@ class HllArray : public HllSketchImpl<A> {
     void putKxQ1(double kxq1);
     void putNumAtCurMin(int numAtCurMin);
 
-    static int hllArrBytes(TgtHllType tgtHllType, int lgConfigK);
+    static int hllArrBytes(target_hll_type tgtHllType, int lgConfigK);
     static int hll4ArrBytes(int lgConfigK);
     static int hll6ArrBytes(int lgConfigK);
     static int hll8ArrBytes(int lgConfigK);

--- a/hll/include/HllSketch-internal.hpp
+++ b/hll/include/HllSketch-internal.hpp
@@ -46,7 +46,7 @@ hll_sketch_alloc<A>::hll_sketch_alloc(int lg_config_k, target_hll_type tgt_type,
     sketch_impl = HllSketchImplFactory<A>::newHll(lg_config_k, tgt_type, start_full_size);
   } else {
     typedef typename std::allocator_traits<A>::template rebind_alloc<CouponList<A>> clAlloc;
-    sketch_impl = new (clAlloc().allocate(1)) CouponList<A>(lg_config_k, tgt_type, CurMode::LIST);
+    sketch_impl = new (clAlloc().allocate(1)) CouponList<A>(lg_config_k, tgt_type, hll_mode::LIST);
   }
 }
 
@@ -344,7 +344,7 @@ double hll_sketch_alloc<A>::get_upper_bound(int numStdDev) const {
 }
 
 template<typename A>
-CurMode hll_sketch_alloc<A>::get_current_mode() const {
+hll_mode hll_sketch_alloc<A>::get_current_mode() const {
   return sketch_impl->getCurMode();
 }
 
@@ -417,7 +417,7 @@ std::string hll_sketch_alloc<A>::mode_as_string() const {
     case HLL:
       return std::string("HLL");
     default:
-      throw std::runtime_error("Sketch state error: Invalid CurMode");
+      throw std::runtime_error("Sketch state error: Invalid hll_mode");
   }
 }
 

--- a/hll/include/HllSketch-internal.hpp
+++ b/hll/include/HllSketch-internal.hpp
@@ -40,7 +40,7 @@ typedef union {
 } longDoubleUnion;
 
 template<typename A>
-HllSketch<A>::HllSketch(int lgConfigK, TgtHllType tgtHllType, bool startFullSize) {
+hll_sketch_alloc<A>::hll_sketch_alloc(int lgConfigK, target_hll_type tgtHllType, bool startFullSize) {
   HllUtil<A>::checkLgK(lgConfigK);
   if (startFullSize) {
     hllSketchImpl = HllSketchImplFactory<A>::newHll(lgConfigK, tgtHllType, startFullSize);
@@ -51,75 +51,75 @@ HllSketch<A>::HllSketch(int lgConfigK, TgtHllType tgtHllType, bool startFullSize
 }
 
 template<typename A>
-HllSketch<A> HllSketch<A>::deserialize(std::istream& is) {
+hll_sketch_alloc<A> hll_sketch_alloc<A>::deserialize(std::istream& is) {
   HllSketchImpl<A>* impl = HllSketchImplFactory<A>::deserialize(is);
-  HllSketch<A> sketch(impl);
+  hll_sketch_alloc<A> sketch(impl);
   return sketch;
 }
 
 template<typename A>
-HllSketch<A> HllSketch<A>::deserialize(const void* bytes, size_t len) {
+hll_sketch_alloc<A> hll_sketch_alloc<A>::deserialize(const void* bytes, size_t len) {
   HllSketchImpl<A>* impl = HllSketchImplFactory<A>::deserialize(bytes, len);
-  HllSketch<A> sketch(impl);
+  hll_sketch_alloc<A> sketch(impl);
   return sketch;
 }
 
 template<typename A>
-HllSketch<A>::~HllSketch() {
+hll_sketch_alloc<A>::~hll_sketch_alloc() {
   if (hllSketchImpl != nullptr) {
     hllSketchImpl->get_deleter()(hllSketchImpl);
   }
 }
 
 template<typename A>
-std::ostream& operator<<(std::ostream& os, const HllSketch<A>& sketch) {
+std::ostream& operator<<(std::ostream& os, const hll_sketch_alloc<A>& sketch) {
   return sketch.to_string(os, true, true, false, false);
 }
 
 template<typename A>
-HllSketch<A>::HllSketch(const HllSketch<A>& that) :
+hll_sketch_alloc<A>::hll_sketch_alloc(const hll_sketch_alloc<A>& that) :
   hllSketchImpl(that.hllSketchImpl->copy())
 {}
 
 template<typename A>
-HllSketch<A>::HllSketch(const HllSketch<A>& that, TgtHllType tgtHllType) :
+hll_sketch_alloc<A>::hll_sketch_alloc(const hll_sketch_alloc<A>& that, target_hll_type tgtHllType) :
   hllSketchImpl(that.hllSketchImpl->copyAs(tgtHllType))
 {}
 
 template<typename A>
-HllSketch<A>::HllSketch(HllSketch<A>&& that) noexcept :
+hll_sketch_alloc<A>::hll_sketch_alloc(hll_sketch_alloc<A>&& that) noexcept :
   hllSketchImpl(nullptr)
 {
   std::swap(hllSketchImpl, that.hllSketchImpl);
 }
 
 template<typename A>
-HllSketch<A>::HllSketch(HllSketchImpl<A>* that) :
+hll_sketch_alloc<A>::hll_sketch_alloc(HllSketchImpl<A>* that) :
   hllSketchImpl(that)
 {}
 
 template<typename A>
-HllSketch<A> HllSketch<A>::operator=(const HllSketch<A>& other) {
+hll_sketch_alloc<A> hll_sketch_alloc<A>::operator=(const hll_sketch_alloc<A>& other) {
   hllSketchImpl->get_deleter()(hllSketchImpl);
   hllSketchImpl = other.hllSketchImpl->copy();
   return *this;
 }
 
 template<typename A>
-HllSketch<A> HllSketch<A>::operator=(HllSketch<A>&& other) {
+hll_sketch_alloc<A> hll_sketch_alloc<A>::operator=(hll_sketch_alloc<A>&& other) {
   std::swap(hllSketchImpl, other.hllSketchImpl);
   return *this;
 }
 
 template<typename A>
-void HllSketch<A>::reset() {
+void hll_sketch_alloc<A>::reset() {
   // TODO: need to allow starting from a full-sized sketch
   //       (either here or in other implementation)
   hllSketchImpl = hllSketchImpl->reset();
 }
 
 template<typename A>
-void HllSketch<A>::update(const std::string& datum) {
+void hll_sketch_alloc<A>::update(const std::string& datum) {
   if (datum.empty()) { return; }
   HashState hashResult;
   HllUtil<A>::hash(datum.c_str(), datum.length(), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
@@ -127,7 +127,7 @@ void HllSketch<A>::update(const std::string& datum) {
 }
 
 template<typename A>
-void HllSketch<A>::update(const uint64_t datum) {
+void hll_sketch_alloc<A>::update(const uint64_t datum) {
   // no sign extension with 64 bits so no need to cast to signed value
   HashState hashResult;
   HllUtil<A>::hash(&datum, sizeof(uint64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
@@ -135,29 +135,29 @@ void HllSketch<A>::update(const uint64_t datum) {
 }
 
 template<typename A>
-void HllSketch<A>::update(const uint32_t datum) {
+void hll_sketch_alloc<A>::update(const uint32_t datum) {
   update(static_cast<int32_t>(datum));
 }
 
 template<typename A>
-void HllSketch<A>::update(const uint16_t datum) {
+void hll_sketch_alloc<A>::update(const uint16_t datum) {
   update(static_cast<int16_t>(datum));
 }
 
 template<typename A>
-void HllSketch<A>::update(const uint8_t datum) {
+void hll_sketch_alloc<A>::update(const uint8_t datum) {
   update(static_cast<int8_t>(datum));
 }
 
 template<typename A>
-void HllSketch<A>::update(const int64_t datum) {
+void hll_sketch_alloc<A>::update(const int64_t datum) {
   HashState hashResult;
   HllUtil<A>::hash(&datum, sizeof(int64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
   couponUpdate(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
-void HllSketch<A>::update(const int32_t datum) {
+void hll_sketch_alloc<A>::update(const int32_t datum) {
   int64_t val = static_cast<int64_t>(datum);
   HashState hashResult;
   HllUtil<A>::hash(&val, sizeof(int64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
@@ -165,7 +165,7 @@ void HllSketch<A>::update(const int32_t datum) {
 }
 
 template<typename A>
-void HllSketch<A>::update(const int16_t datum) {
+void hll_sketch_alloc<A>::update(const int16_t datum) {
   int64_t val = static_cast<int64_t>(datum);
   HashState hashResult;
   HllUtil<A>::hash(&val, sizeof(int64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
@@ -173,7 +173,7 @@ void HllSketch<A>::update(const int16_t datum) {
 }
 
 template<typename A>
-void HllSketch<A>::update(const int8_t datum) {
+void hll_sketch_alloc<A>::update(const int8_t datum) {
   int64_t val = static_cast<int64_t>(datum);
   HashState hashResult;
   HllUtil<A>::hash(&val, sizeof(int64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
@@ -181,7 +181,7 @@ void HllSketch<A>::update(const int8_t datum) {
 }
 
 template<typename A>
-void HllSketch<A>::update(const double datum) {
+void hll_sketch_alloc<A>::update(const double datum) {
   longDoubleUnion d;
   d.doubleBytes = static_cast<double>(datum);
   if (datum == 0.0) {
@@ -195,7 +195,7 @@ void HllSketch<A>::update(const double datum) {
 }
 
 template<typename A>
-void HllSketch<A>::update(const float datum) {
+void hll_sketch_alloc<A>::update(const float datum) {
   longDoubleUnion d;
   d.doubleBytes = static_cast<double>(datum);
   if (datum == 0.0) {
@@ -209,7 +209,7 @@ void HllSketch<A>::update(const float datum) {
 }
 
 template<typename A>
-void HllSketch<A>::update(const void* data, const size_t lengthBytes) {
+void hll_sketch_alloc<A>::update(const void* data, const size_t lengthBytes) {
   if (data == nullptr) { return; }
   HashState hashResult;
   HllUtil<A>::hash(data, lengthBytes, HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
@@ -217,7 +217,7 @@ void HllSketch<A>::update(const void* data, const size_t lengthBytes) {
 }
 
 template<typename A>
-void HllSketch<A>::couponUpdate(int coupon) {
+void hll_sketch_alloc<A>::couponUpdate(int coupon) {
   if (coupon == HllUtil<A>::EMPTY) { return; }
   HllSketchImpl<A>* result = this->hllSketchImpl->couponUpdate(coupon);
   if (result != this->hllSketchImpl) {
@@ -227,29 +227,29 @@ void HllSketch<A>::couponUpdate(int coupon) {
 }
 
 template<typename A>
-void HllSketch<A>::serializeCompact(std::ostream& os) const {
+void hll_sketch_alloc<A>::serialize_compact(std::ostream& os) const {
   return hllSketchImpl->serialize(os, true);
 }
 
 template<typename A>
-void HllSketch<A>::serializeUpdatable(std::ostream& os) const {
+void hll_sketch_alloc<A>::serialize_updatable(std::ostream& os) const {
   return hllSketchImpl->serialize(os, false);
 }
 
 template<typename A>
 std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
-HllSketch<A>::serializeCompact(unsigned header_size_bytes) const {
+hll_sketch_alloc<A>::serialize_compact(unsigned header_size_bytes) const {
   return hllSketchImpl->serialize(true, header_size_bytes);
 }
 
 template<typename A>
 std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
-HllSketch<A>::serializeUpdatable() const {
+hll_sketch_alloc<A>::serialize_updatable() const {
   return hllSketchImpl->serialize(false, 0);
 }
 
 template<typename A>
-std::string HllSketch<A>::to_string(const bool summary,
+std::string hll_sketch_alloc<A>::to_string(const bool summary,
                                     const bool detail,
                                     const bool auxDetail,
                                     const bool all) const {
@@ -259,19 +259,19 @@ std::string HllSketch<A>::to_string(const bool summary,
 }
 
 template<typename A>
-std::ostream& HllSketch<A>::to_string(std::ostream& os,
+std::ostream& hll_sketch_alloc<A>::to_string(std::ostream& os,
                                       const bool summary,
                                       const bool detail,
                                       const bool auxDetail,
                                       const bool all) const {
   if (summary) {
     os << "### HLL SKETCH SUMMARY: " << std::endl
-       << "  Log Config K   : " << getLgConfigK() << std::endl
+       << "  Log Config K   : " << get_lg_config_k() << std::endl
        << "  Hll Target     : " << typeAsString() << std::endl
        << "  Current Mode   : " << modeAsString() << std::endl
-       << "  LB             : " << getLowerBound(1) << std::endl
-       << "  Estimate       : " << getEstimate() << std::endl
-       << "  UB             : " << getUpperBound(1) << std::endl
+       << "  LB             : " << get_lower_bound(1) << std::endl
+       << "  Estimate       : " << get_estimate() << std::endl
+       << "  UB             : " << get_upper_bound(1) << std::endl
        << "  OutOfOrder flag: " << isOutOfOrderFlag() << std::endl;
     if (getCurrentMode() == HLL) {
       HllArray<A>* hllArray = (HllArray<A>*) hllSketchImpl;
@@ -288,8 +288,7 @@ std::ostream& HllSketch<A>::to_string(std::ostream& os,
 
   if (detail) {
     os << "### HLL SKETCH DATA DETAIL: " << std::endl;
-    //std::unique_ptr<PairIterator<A>> pitr = getIterator();
-    PairIterator_with_deleter<A> pitr = getIterator();
+    pair_iterator_with_deleter<A> pitr = get_iterator();
     os << pitr->getHeader() << std::endl;
     if (all) {
       while (pitr->nextAll()) {
@@ -302,10 +301,9 @@ std::ostream& HllSketch<A>::to_string(std::ostream& os,
     }
   }
   if (auxDetail) {
-    if ((getCurrentMode() == HLL) && (getTgtHllType() == HLL_4)) {
+    if ((getCurrentMode() == HLL) && (get_target_type() == HLL_4)) {
       HllArray<A>* hllArray = (HllArray<A>*) hllSketchImpl;
-      //std::unique_ptr<PairIterator<A>> auxItr = hllArray->getAuxIterator();
-      PairIterator_with_deleter<A> auxItr = hllArray->getAuxIterator();
+      pair_iterator_with_deleter<A> auxItr = hllArray->getAuxIterator();
       if (auxItr != nullptr) {
         os << "### HLL SKETCH AUX DETAIL: " << std::endl
            << auxItr->getHeader() << std::endl;
@@ -326,91 +324,91 @@ std::ostream& HllSketch<A>::to_string(std::ostream& os,
 }
 
 template<typename A>
-double HllSketch<A>::getEstimate() const {
+double hll_sketch_alloc<A>::get_estimate() const {
   return hllSketchImpl->getEstimate();
 }
 
 template<typename A>
-double HllSketch<A>::getCompositeEstimate() const {
+double hll_sketch_alloc<A>::get_composite_estimate() const {
   return hllSketchImpl->getCompositeEstimate();
 }
 
 template<typename A>
-double HllSketch<A>::getLowerBound(int numStdDev) const {
+double hll_sketch_alloc<A>::get_lower_bound(int numStdDev) const {
   return hllSketchImpl->getLowerBound(numStdDev);
 }
 
 template<typename A>
-double HllSketch<A>::getUpperBound(int numStdDev) const {
+double hll_sketch_alloc<A>::get_upper_bound(int numStdDev) const {
   return hllSketchImpl->getUpperBound(numStdDev);
 }
 
 template<typename A>
-CurMode HllSketch<A>::getCurrentMode() const {
+CurMode hll_sketch_alloc<A>::getCurrentMode() const {
   return hllSketchImpl->getCurMode();
 }
 
 template<typename A>
-int HllSketch<A>::getLgConfigK() const {
+int hll_sketch_alloc<A>::get_lg_config_k() const {
   return hllSketchImpl->getLgConfigK();
 }
 
 template<typename A>
-TgtHllType HllSketch<A>::getTgtHllType() const {
+target_hll_type hll_sketch_alloc<A>::get_target_type() const {
   return hllSketchImpl->getTgtHllType();
 }
 
 template<typename A>
-bool HllSketch<A>::isOutOfOrderFlag() const {
+bool hll_sketch_alloc<A>::isOutOfOrderFlag() const {
   return hllSketchImpl->isOutOfOrderFlag();
 }
 
 template<typename A>
-bool HllSketch<A>::isEstimationMode() const {
+bool hll_sketch_alloc<A>::isEstimationMode() const {
   return true;
 }
 
 template<typename A>
-int HllSketch<A>::getUpdatableSerializationBytes() const {
+int hll_sketch_alloc<A>::get_updatable_serialization_bytes() const {
   return hllSketchImpl->getUpdatableSerializationBytes();
 }
 
 template<typename A>
-int HllSketch<A>::getCompactSerializationBytes() const {
+int hll_sketch_alloc<A>::get_compact_serialization_bytes() const {
   return hllSketchImpl->getCompactSerializationBytes();
 }
 
 template<typename A>
-bool HllSketch<A>::isCompact() const {
+bool hll_sketch_alloc<A>::is_compact() const {
   return hllSketchImpl->isCompact();
 }
 
 template<typename A>
-bool HllSketch<A>::isEmpty() const {
+bool hll_sketch_alloc<A>::is_empty() const {
   return hllSketchImpl->isEmpty();
 }
 
 template<typename A>
-PairIterator_with_deleter<A> HllSketch<A>::getIterator() const {
+pair_iterator_with_deleter<A> hll_sketch_alloc<A>::get_iterator() const {
   return hllSketchImpl->getIterator();
 }
 
 template<typename A>
-std::string HllSketch<A>::typeAsString() const {
+std::string hll_sketch_alloc<A>::typeAsString() const {
   switch (hllSketchImpl->getTgtHllType()) {
-    case TgtHllType::HLL_4:
+    case target_hll_type::HLL_4:
       return std::string("HLL_4");
-    case TgtHllType::HLL_6:
+    case target_hll_type::HLL_6:
       return std::string("HLL_6");
-    case TgtHllType::HLL_8:
+    case target_hll_type::HLL_8:
       return std::string("HLL_8");
     default:
-      throw std::runtime_error("Sketch state error: Invalid TgtHllType");
+      throw std::runtime_error("Sketch state error: Invalid target_hll_type");
   }
 }
 
 template<typename A>
-std::string HllSketch<A>::modeAsString() const {
+std::string hll_sketch_alloc<A>::modeAsString() const {
   switch (hllSketchImpl->getCurMode()) {
     case LIST:
       return std::string("LIST");
@@ -424,13 +422,13 @@ std::string HllSketch<A>::modeAsString() const {
 }
 
 template<typename A>
-int HllSketch<A>::getMaxUpdatableSerializationBytes(const int lgConfigK,
-    const TgtHllType tgtHllType) {
+int hll_sketch_alloc<A>::get_max_updatable_serialization_bytes(const int lgConfigK,
+    const target_hll_type tgtHllType) {
   int arrBytes;
-  if (tgtHllType == TgtHllType::HLL_4) {
+  if (tgtHllType == target_hll_type::HLL_4) {
     const int auxBytes = 4 << HllUtil<A>::LG_AUX_ARR_INTS[lgConfigK];
     arrBytes = HllArray<A>::hll4ArrBytes(lgConfigK) + auxBytes;
-  } else if (tgtHllType == TgtHllType::HLL_6) {
+  } else if (tgtHllType == target_hll_type::HLL_6) {
     arrBytes = HllArray<A>::hll6ArrBytes(lgConfigK);
   } else { //HLL_8
     arrBytes = HllArray<A>::hll8ArrBytes(lgConfigK);
@@ -439,7 +437,7 @@ int HllSketch<A>::getMaxUpdatableSerializationBytes(const int lgConfigK,
 }
 
 template<typename A>
-double HllSketch<A>::getRelErr(const bool upperBound, const bool unioned,
+double hll_sketch_alloc<A>::get_rel_err(const bool upperBound, const bool unioned,
                            const int lgConfigK, const int numStdDev) {
   return HllUtil<A>::getRelErr(upperBound, unioned, lgConfigK, numStdDev);
 }

--- a/hll/include/HllSketch-internal.hpp
+++ b/hll/include/HllSketch-internal.hpp
@@ -40,13 +40,13 @@ typedef union {
 } longDoubleUnion;
 
 template<typename A>
-hll_sketch_alloc<A>::hll_sketch_alloc(int lgConfigK, target_hll_type tgtHllType, bool startFullSize) {
-  HllUtil<A>::checkLgK(lgConfigK);
-  if (startFullSize) {
-    hllSketchImpl = HllSketchImplFactory<A>::newHll(lgConfigK, tgtHllType, startFullSize);
+hll_sketch_alloc<A>::hll_sketch_alloc(int lg_config_k, target_hll_type tgt_type, bool start_full_size) {
+  HllUtil<A>::checkLgK(lg_config_k);
+  if (start_full_size) {
+    sketch_impl = HllSketchImplFactory<A>::newHll(lg_config_k, tgt_type, start_full_size);
   } else {
     typedef typename std::allocator_traits<A>::template rebind_alloc<CouponList<A>> clAlloc;
-    hllSketchImpl = new (clAlloc().allocate(1)) CouponList<A>(lgConfigK, tgtHllType, CurMode::LIST);
+    sketch_impl = new (clAlloc().allocate(1)) CouponList<A>(lg_config_k, tgt_type, CurMode::LIST);
   }
 }
 
@@ -66,8 +66,8 @@ hll_sketch_alloc<A> hll_sketch_alloc<A>::deserialize(const void* bytes, size_t l
 
 template<typename A>
 hll_sketch_alloc<A>::~hll_sketch_alloc() {
-  if (hllSketchImpl != nullptr) {
-    hllSketchImpl->get_deleter()(hllSketchImpl);
+  if (sketch_impl != nullptr) {
+    sketch_impl->get_deleter()(sketch_impl);
   }
 }
 
@@ -78,36 +78,36 @@ std::ostream& operator<<(std::ostream& os, const hll_sketch_alloc<A>& sketch) {
 
 template<typename A>
 hll_sketch_alloc<A>::hll_sketch_alloc(const hll_sketch_alloc<A>& that) :
-  hllSketchImpl(that.hllSketchImpl->copy())
+  sketch_impl(that.sketch_impl->copy())
 {}
 
 template<typename A>
-hll_sketch_alloc<A>::hll_sketch_alloc(const hll_sketch_alloc<A>& that, target_hll_type tgtHllType) :
-  hllSketchImpl(that.hllSketchImpl->copyAs(tgtHllType))
+hll_sketch_alloc<A>::hll_sketch_alloc(const hll_sketch_alloc<A>& that, target_hll_type tgt_type) :
+  sketch_impl(that.sketch_impl->copyAs(tgt_type))
 {}
 
 template<typename A>
 hll_sketch_alloc<A>::hll_sketch_alloc(hll_sketch_alloc<A>&& that) noexcept :
-  hllSketchImpl(nullptr)
+  sketch_impl(nullptr)
 {
-  std::swap(hllSketchImpl, that.hllSketchImpl);
+  std::swap(sketch_impl, that.sketch_impl);
 }
 
 template<typename A>
 hll_sketch_alloc<A>::hll_sketch_alloc(HllSketchImpl<A>* that) :
-  hllSketchImpl(that)
+  sketch_impl(that)
 {}
 
 template<typename A>
 hll_sketch_alloc<A> hll_sketch_alloc<A>::operator=(const hll_sketch_alloc<A>& other) {
-  hllSketchImpl->get_deleter()(hllSketchImpl);
-  hllSketchImpl = other.hllSketchImpl->copy();
+  sketch_impl->get_deleter()(sketch_impl);
+  sketch_impl = other.sketch_impl->copy();
   return *this;
 }
 
 template<typename A>
 hll_sketch_alloc<A> hll_sketch_alloc<A>::operator=(hll_sketch_alloc<A>&& other) {
-  std::swap(hllSketchImpl, other.hllSketchImpl);
+  std::swap(sketch_impl, other.sketch_impl);
   return *this;
 }
 
@@ -115,7 +115,7 @@ template<typename A>
 void hll_sketch_alloc<A>::reset() {
   // TODO: need to allow starting from a full-sized sketch
   //       (either here or in other implementation)
-  hllSketchImpl = hllSketchImpl->reset();
+  sketch_impl = sketch_impl->reset();
 }
 
 template<typename A>
@@ -123,7 +123,7 @@ void hll_sketch_alloc<A>::update(const std::string& datum) {
   if (datum.empty()) { return; }
   HashState hashResult;
   HllUtil<A>::hash(datum.c_str(), datum.length(), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
@@ -131,7 +131,7 @@ void hll_sketch_alloc<A>::update(const uint64_t datum) {
   // no sign extension with 64 bits so no need to cast to signed value
   HashState hashResult;
   HllUtil<A>::hash(&datum, sizeof(uint64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
@@ -153,7 +153,7 @@ template<typename A>
 void hll_sketch_alloc<A>::update(const int64_t datum) {
   HashState hashResult;
   HllUtil<A>::hash(&datum, sizeof(int64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
@@ -161,7 +161,7 @@ void hll_sketch_alloc<A>::update(const int32_t datum) {
   int64_t val = static_cast<int64_t>(datum);
   HashState hashResult;
   HllUtil<A>::hash(&val, sizeof(int64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
@@ -169,7 +169,7 @@ void hll_sketch_alloc<A>::update(const int16_t datum) {
   int64_t val = static_cast<int64_t>(datum);
   HashState hashResult;
   HllUtil<A>::hash(&val, sizeof(int64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
@@ -177,7 +177,7 @@ void hll_sketch_alloc<A>::update(const int8_t datum) {
   int64_t val = static_cast<int64_t>(datum);
   HashState hashResult;
   HllUtil<A>::hash(&val, sizeof(int64_t), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
@@ -191,7 +191,7 @@ void hll_sketch_alloc<A>::update(const double datum) {
   }
   HashState hashResult;
   HllUtil<A>::hash(&d, sizeof(double), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
@@ -205,7 +205,7 @@ void hll_sketch_alloc<A>::update(const float datum) {
   }
   HashState hashResult;
   HllUtil<A>::hash(&d, sizeof(double), HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
@@ -213,48 +213,48 @@ void hll_sketch_alloc<A>::update(const void* data, const size_t lengthBytes) {
   if (data == nullptr) { return; }
   HashState hashResult;
   HllUtil<A>::hash(data, lengthBytes, HllUtil<A>::DEFAULT_UPDATE_SEED, hashResult);
-  couponUpdate(HllUtil<A>::coupon(hashResult));
+  coupon_update(HllUtil<A>::coupon(hashResult));
 }
 
 template<typename A>
-void hll_sketch_alloc<A>::couponUpdate(int coupon) {
+void hll_sketch_alloc<A>::coupon_update(int coupon) {
   if (coupon == HllUtil<A>::EMPTY) { return; }
-  HllSketchImpl<A>* result = this->hllSketchImpl->couponUpdate(coupon);
-  if (result != this->hllSketchImpl) {
-    this->hllSketchImpl->get_deleter()(this->hllSketchImpl);
-    this->hllSketchImpl = result;
+  HllSketchImpl<A>* result = this->sketch_impl->couponUpdate(coupon);
+  if (result != this->sketch_impl) {
+    this->sketch_impl->get_deleter()(this->sketch_impl);
+    this->sketch_impl = result;
   }
 }
 
 template<typename A>
 void hll_sketch_alloc<A>::serialize_compact(std::ostream& os) const {
-  return hllSketchImpl->serialize(os, true);
+  return sketch_impl->serialize(os, true);
 }
 
 template<typename A>
 void hll_sketch_alloc<A>::serialize_updatable(std::ostream& os) const {
-  return hllSketchImpl->serialize(os, false);
+  return sketch_impl->serialize(os, false);
 }
 
 template<typename A>
 std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
 hll_sketch_alloc<A>::serialize_compact(unsigned header_size_bytes) const {
-  return hllSketchImpl->serialize(true, header_size_bytes);
+  return sketch_impl->serialize(true, header_size_bytes);
 }
 
 template<typename A>
 std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
 hll_sketch_alloc<A>::serialize_updatable() const {
-  return hllSketchImpl->serialize(false, 0);
+  return sketch_impl->serialize(false, 0);
 }
 
 template<typename A>
 std::string hll_sketch_alloc<A>::to_string(const bool summary,
                                     const bool detail,
-                                    const bool auxDetail,
+                                    const bool aux_detail,
                                     const bool all) const {
   std::ostringstream oss;
-  to_string(oss, summary, detail, auxDetail, all);
+  to_string(oss, summary, detail, aux_detail, all);
   return oss.str();
 }
 
@@ -262,19 +262,19 @@ template<typename A>
 std::ostream& hll_sketch_alloc<A>::to_string(std::ostream& os,
                                       const bool summary,
                                       const bool detail,
-                                      const bool auxDetail,
+                                      const bool aux_detail,
                                       const bool all) const {
   if (summary) {
     os << "### HLL SKETCH SUMMARY: " << std::endl
        << "  Log Config K   : " << get_lg_config_k() << std::endl
-       << "  Hll Target     : " << typeAsString() << std::endl
-       << "  Current Mode   : " << modeAsString() << std::endl
+       << "  Hll Target     : " << type_as_string() << std::endl
+       << "  Current Mode   : " << mode_as_string() << std::endl
        << "  LB             : " << get_lower_bound(1) << std::endl
        << "  Estimate       : " << get_estimate() << std::endl
        << "  UB             : " << get_upper_bound(1) << std::endl
-       << "  OutOfOrder flag: " << isOutOfOrderFlag() << std::endl;
-    if (getCurrentMode() == HLL) {
-      HllArray<A>* hllArray = (HllArray<A>*) hllSketchImpl;
+       << "  OutOfOrder flag: " << is_out_of_order_flag() << std::endl;
+    if (get_current_mode() == HLL) {
+      HllArray<A>* hllArray = (HllArray<A>*) sketch_impl;
       os << "  CurMin       : " << hllArray->getCurMin() << std::endl
          << "  NumAtCurMin  : " << hllArray->getNumAtCurMin() << std::endl
          << "  HipAccum     : " << hllArray->getHipAccum() << std::endl
@@ -282,7 +282,7 @@ std::ostream& hll_sketch_alloc<A>::to_string(std::ostream& os,
          << "  KxQ1         : " << hllArray->getKxQ1() << std::endl;
     } else {
       os << "  Coupon count : "
-         << std::to_string(((CouponList<A>*) hllSketchImpl)->getCouponCount()) << std::endl;
+         << std::to_string(((CouponList<A>*) sketch_impl)->getCouponCount()) << std::endl;
     }
   }
 
@@ -300,9 +300,9 @@ std::ostream& hll_sketch_alloc<A>::to_string(std::ostream& os,
       }
     }
   }
-  if (auxDetail) {
-    if ((getCurrentMode() == HLL) && (get_target_type() == HLL_4)) {
-      HllArray<A>* hllArray = (HllArray<A>*) hllSketchImpl;
+  if (aux_detail) {
+    if ((get_current_mode() == HLL) && (get_target_type() == HLL_4)) {
+      HllArray<A>* hllArray = (HllArray<A>*) sketch_impl;
       pair_iterator_with_deleter<A> auxItr = hllArray->getAuxIterator();
       if (auxItr != nullptr) {
         os << "### HLL SKETCH AUX DETAIL: " << std::endl
@@ -325,77 +325,77 @@ std::ostream& hll_sketch_alloc<A>::to_string(std::ostream& os,
 
 template<typename A>
 double hll_sketch_alloc<A>::get_estimate() const {
-  return hllSketchImpl->getEstimate();
+  return sketch_impl->getEstimate();
 }
 
 template<typename A>
 double hll_sketch_alloc<A>::get_composite_estimate() const {
-  return hllSketchImpl->getCompositeEstimate();
+  return sketch_impl->getCompositeEstimate();
 }
 
 template<typename A>
 double hll_sketch_alloc<A>::get_lower_bound(int numStdDev) const {
-  return hllSketchImpl->getLowerBound(numStdDev);
+  return sketch_impl->getLowerBound(numStdDev);
 }
 
 template<typename A>
 double hll_sketch_alloc<A>::get_upper_bound(int numStdDev) const {
-  return hllSketchImpl->getUpperBound(numStdDev);
+  return sketch_impl->getUpperBound(numStdDev);
 }
 
 template<typename A>
-CurMode hll_sketch_alloc<A>::getCurrentMode() const {
-  return hllSketchImpl->getCurMode();
+CurMode hll_sketch_alloc<A>::get_current_mode() const {
+  return sketch_impl->getCurMode();
 }
 
 template<typename A>
 int hll_sketch_alloc<A>::get_lg_config_k() const {
-  return hllSketchImpl->getLgConfigK();
+  return sketch_impl->getLgConfigK();
 }
 
 template<typename A>
 target_hll_type hll_sketch_alloc<A>::get_target_type() const {
-  return hllSketchImpl->getTgtHllType();
+  return sketch_impl->getTgtHllType();
 }
 
 template<typename A>
-bool hll_sketch_alloc<A>::isOutOfOrderFlag() const {
-  return hllSketchImpl->isOutOfOrderFlag();
+bool hll_sketch_alloc<A>::is_out_of_order_flag() const {
+  return sketch_impl->isOutOfOrderFlag();
 }
 
 template<typename A>
-bool hll_sketch_alloc<A>::isEstimationMode() const {
+bool hll_sketch_alloc<A>::is_estimation_mode() const {
   return true;
 }
 
 template<typename A>
 int hll_sketch_alloc<A>::get_updatable_serialization_bytes() const {
-  return hllSketchImpl->getUpdatableSerializationBytes();
+  return sketch_impl->getUpdatableSerializationBytes();
 }
 
 template<typename A>
 int hll_sketch_alloc<A>::get_compact_serialization_bytes() const {
-  return hllSketchImpl->getCompactSerializationBytes();
+  return sketch_impl->getCompactSerializationBytes();
 }
 
 template<typename A>
 bool hll_sketch_alloc<A>::is_compact() const {
-  return hllSketchImpl->isCompact();
+  return sketch_impl->isCompact();
 }
 
 template<typename A>
 bool hll_sketch_alloc<A>::is_empty() const {
-  return hllSketchImpl->isEmpty();
+  return sketch_impl->isEmpty();
 }
 
 template<typename A>
 pair_iterator_with_deleter<A> hll_sketch_alloc<A>::get_iterator() const {
-  return hllSketchImpl->getIterator();
+  return sketch_impl->getIterator();
 }
 
 template<typename A>
-std::string hll_sketch_alloc<A>::typeAsString() const {
-  switch (hllSketchImpl->getTgtHllType()) {
+std::string hll_sketch_alloc<A>::type_as_string() const {
+  switch (sketch_impl->getTgtHllType()) {
     case target_hll_type::HLL_4:
       return std::string("HLL_4");
     case target_hll_type::HLL_6:
@@ -408,8 +408,8 @@ std::string hll_sketch_alloc<A>::typeAsString() const {
 }
 
 template<typename A>
-std::string hll_sketch_alloc<A>::modeAsString() const {
-  switch (hllSketchImpl->getCurMode()) {
+std::string hll_sketch_alloc<A>::mode_as_string() const {
+  switch (sketch_impl->getCurMode()) {
     case LIST:
       return std::string("LIST");
     case SET:
@@ -422,24 +422,24 @@ std::string hll_sketch_alloc<A>::modeAsString() const {
 }
 
 template<typename A>
-int hll_sketch_alloc<A>::get_max_updatable_serialization_bytes(const int lgConfigK,
+int hll_sketch_alloc<A>::get_max_updatable_serialization_bytes(const int lg_config_k,
     const target_hll_type tgtHllType) {
   int arrBytes;
   if (tgtHllType == target_hll_type::HLL_4) {
-    const int auxBytes = 4 << HllUtil<A>::LG_AUX_ARR_INTS[lgConfigK];
-    arrBytes = HllArray<A>::hll4ArrBytes(lgConfigK) + auxBytes;
+    const int auxBytes = 4 << HllUtil<A>::LG_AUX_ARR_INTS[lg_config_k];
+    arrBytes = HllArray<A>::hll4ArrBytes(lg_config_k) + auxBytes;
   } else if (tgtHllType == target_hll_type::HLL_6) {
-    arrBytes = HllArray<A>::hll6ArrBytes(lgConfigK);
+    arrBytes = HllArray<A>::hll6ArrBytes(lg_config_k);
   } else { //HLL_8
-    arrBytes = HllArray<A>::hll8ArrBytes(lgConfigK);
+    arrBytes = HllArray<A>::hll8ArrBytes(lg_config_k);
   }
   return HllUtil<A>::HLL_BYTE_ARR_START + arrBytes;
 }
 
 template<typename A>
 double hll_sketch_alloc<A>::get_rel_err(const bool upperBound, const bool unioned,
-                           const int lgConfigK, const int numStdDev) {
-  return HllUtil<A>::getRelErr(upperBound, unioned, lgConfigK, numStdDev);
+                           const int lg_config_k, const int numStdDev) {
+  return HllUtil<A>::getRelErr(upperBound, unioned, lg_config_k, numStdDev);
 }
 
 }

--- a/hll/include/HllSketchImpl-internal.hpp
+++ b/hll/include/HllSketchImpl-internal.hpp
@@ -27,10 +27,10 @@ namespace datasketches {
 
 template<typename A>
 HllSketchImpl<A>::HllSketchImpl(const int lgConfigK, const target_hll_type tgtHllType,
-                                const CurMode curMode, const bool startFullSize)
+                                const hll_mode mode, const bool startFullSize)
   : lgConfigK(lgConfigK),
     tgtHllType(tgtHllType),
-    curMode(curMode),
+    mode(mode),
     startFullSize(startFullSize)
 {
 }
@@ -54,14 +54,14 @@ target_hll_type HllSketchImpl<A>::extractTgtHllType(const uint8_t modeByte) {
 }
 
 template<typename A>
-CurMode HllSketchImpl<A>::extractCurMode(const uint8_t modeByte) {
+hll_mode HllSketchImpl<A>::extractCurMode(const uint8_t modeByte) {
   switch (modeByte & 0x3) {
   case 0:
-    return CurMode::LIST;
+    return hll_mode::LIST;
   case 1:
-    return CurMode::SET;
+    return hll_mode::SET;
   case 2:
-    return CurMode::HLL;
+    return hll_mode::HLL;
   default:
     throw std::invalid_argument("Invalid current sketch mode");
   }
@@ -92,7 +92,7 @@ template<typename A>
 uint8_t HllSketchImpl<A>::makeModeByte() const {
   uint8_t byte = 0;
 
-  switch (curMode) {
+  switch (mode) {
   case LIST:
     byte = 0;
     break;
@@ -135,8 +135,8 @@ int HllSketchImpl<A>::getLgConfigK() const {
 }
 
 template<typename A>
-CurMode HllSketchImpl<A>::getCurMode() const {
-  return curMode;
+hll_mode HllSketchImpl<A>::getCurMode() const {
+  return mode;
 }
 
 template<typename A>

--- a/hll/include/HllSketchImpl-internal.hpp
+++ b/hll/include/HllSketchImpl-internal.hpp
@@ -26,7 +26,7 @@
 namespace datasketches {
 
 template<typename A>
-HllSketchImpl<A>::HllSketchImpl(const int lgConfigK, const TgtHllType tgtHllType,
+HllSketchImpl<A>::HllSketchImpl(const int lgConfigK, const target_hll_type tgtHllType,
                                 const CurMode curMode, const bool startFullSize)
   : lgConfigK(lgConfigK),
     tgtHllType(tgtHllType),
@@ -40,14 +40,14 @@ HllSketchImpl<A>::~HllSketchImpl() {
 }
 
 template<typename A>
-TgtHllType HllSketchImpl<A>::extractTgtHllType(const uint8_t modeByte) {
+target_hll_type HllSketchImpl<A>::extractTgtHllType(const uint8_t modeByte) {
   switch ((modeByte >> 2) & 0x3) {
   case 0:
-    return TgtHllType::HLL_4;
+    return target_hll_type::HLL_4;
   case 1:
-    return TgtHllType::HLL_6;
+    return target_hll_type::HLL_6;
   case 2:
-    return TgtHllType::HLL_8;
+    return target_hll_type::HLL_8;
   default:
     throw std::invalid_argument("Invalid target HLL type");
   }
@@ -125,7 +125,7 @@ HllSketchImpl<A>* HllSketchImpl<A>::reset() {
 }
 
 template<typename A>
-TgtHllType HllSketchImpl<A>::getTgtHllType() const {
+target_hll_type HllSketchImpl<A>::getTgtHllType() const {
   return tgtHllType;
 }
 

--- a/hll/include/HllSketchImpl.hpp
+++ b/hll/include/HllSketchImpl.hpp
@@ -31,7 +31,7 @@ namespace datasketches {
 template<typename A = std::allocator<char>>
 class HllSketchImpl {
   public:
-    HllSketchImpl(int lgConfigK, target_hll_type tgtHllType, CurMode curMode, bool startFullSize);
+    HllSketchImpl(int lgConfigK, target_hll_type tgtHllType, hll_mode mode, bool startFullSize);
     virtual ~HllSketchImpl();
 
     virtual void serialize(std::ostream& os, bool compact) const = 0;
@@ -45,7 +45,7 @@ class HllSketchImpl {
 
     virtual HllSketchImpl* couponUpdate(int coupon) = 0;
 
-    CurMode getCurMode() const;
+    hll_mode getCurMode() const;
 
     virtual double getEstimate() const = 0;
     virtual double getCompositeEstimate() const = 0;
@@ -73,13 +73,13 @@ class HllSketchImpl {
 
   protected:
     static target_hll_type extractTgtHllType(uint8_t modeByte);
-    static CurMode extractCurMode(uint8_t modeByte);
+    static hll_mode extractCurMode(uint8_t modeByte);
     uint8_t makeFlagsByte(bool compact) const;
     uint8_t makeModeByte() const;
 
     const int lgConfigK;
     const target_hll_type tgtHllType;
-    const CurMode curMode;
+    const hll_mode mode;
     const bool startFullSize;
 };
 

--- a/hll/include/HllSketchImpl.hpp
+++ b/hll/include/HllSketchImpl.hpp
@@ -31,14 +31,14 @@ namespace datasketches {
 template<typename A = std::allocator<char>>
 class HllSketchImpl {
   public:
-    HllSketchImpl(int lgConfigK, TgtHllType tgtHllType, CurMode curMode, bool startFullSize);
+    HllSketchImpl(int lgConfigK, target_hll_type tgtHllType, CurMode curMode, bool startFullSize);
     virtual ~HllSketchImpl();
 
     virtual void serialize(std::ostream& os, bool compact) const = 0;
     virtual std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> serialize(bool compact, unsigned header_size_bytes) const = 0;
 
     virtual HllSketchImpl* copy() const = 0;
-    virtual HllSketchImpl* copyAs(TgtHllType tgtHllType) const = 0;
+    virtual HllSketchImpl* copyAs(target_hll_type tgtHllType) const = 0;
     HllSketchImpl<A>* reset();
 
     virtual std::function<void(HllSketchImpl<A>*)> get_deleter() const = 0;
@@ -52,7 +52,7 @@ class HllSketchImpl {
     virtual double getUpperBound(int numStdDev) const = 0;
     virtual double getLowerBound(int numStdDev) const = 0;
 
-    virtual PairIterator_with_deleter<A> getIterator() const = 0;
+    virtual pair_iterator_with_deleter<A> getIterator() const = 0;
 
     int getLgConfigK() const;
 
@@ -60,7 +60,7 @@ class HllSketchImpl {
 
     virtual int getPreInts() const = 0;
 
-    TgtHllType getTgtHllType() const;
+    target_hll_type getTgtHllType() const;
 
     virtual int getUpdatableSerializationBytes() const = 0;
     virtual int getCompactSerializationBytes() const = 0;
@@ -72,13 +72,13 @@ class HllSketchImpl {
     bool isStartFullSize() const;
 
   protected:
-    static TgtHllType extractTgtHllType(uint8_t modeByte);
+    static target_hll_type extractTgtHllType(uint8_t modeByte);
     static CurMode extractCurMode(uint8_t modeByte);
     uint8_t makeFlagsByte(bool compact) const;
     uint8_t makeModeByte() const;
 
     const int lgConfigK;
-    const TgtHllType tgtHllType;
+    const target_hll_type tgtHllType;
     const CurMode curMode;
     const bool startFullSize;
 };

--- a/hll/include/HllSketchImplFactory.hpp
+++ b/hll/include/HllSketchImplFactory.hpp
@@ -39,7 +39,7 @@ public:
 
   static CouponHashSet<A>* promoteListToSet(const CouponList<A>& list);
   static HllArray<A>* promoteListOrSetToHll(const CouponList<A>& list);
-  static HllArray<A>* newHll(int lgConfigK, TgtHllType tgtHllType, bool startFullSize = false);
+  static HllArray<A>* newHll(int lgConfigK, target_hll_type tgtHllType, bool startFullSize = false);
   
   // resets the input impl, deleting the input pointert and returning a new pointer
   static HllSketchImpl<A>* reset(HllSketchImpl<A>* impl, bool startFullSize);
@@ -54,7 +54,7 @@ private:
 
 template<typename A>
 CouponHashSet<A>* HllSketchImplFactory<A>::promoteListToSet(const CouponList<A>& list) {
-  PairIterator_with_deleter<A> iter = list.getIterator();
+  pair_iterator_with_deleter<A> iter = list.getIterator();
 
   typedef typename std::allocator_traits<A>::template rebind_alloc<CouponHashSet<A>> chsAlloc;
   CouponHashSet<A>* chSet = new (chsAlloc().allocate(1)) CouponHashSet<A>(list.getLgConfigK(), list.getTgtHllType());
@@ -69,7 +69,7 @@ CouponHashSet<A>* HllSketchImplFactory<A>::promoteListToSet(const CouponList<A>&
 template<typename A>
 HllArray<A>* HllSketchImplFactory<A>::promoteListOrSetToHll(const CouponList<A>& src) {
   HllArray<A>* tgtHllArr = HllSketchImplFactory<A>::newHll(src.getLgConfigK(), src.getTgtHllType());
-  PairIterator_with_deleter<A> srcItr = src.getIterator();
+  pair_iterator_with_deleter<A> srcItr = src.getIterator();
   tgtHllArr->putKxQ0(1 << src.getLgConfigK());
   while (srcItr->nextValid()) {
     tgtHllArr->couponUpdate(srcItr->getPair());
@@ -111,7 +111,7 @@ HllSketchImpl<A>* HllSketchImplFactory<A>::deserialize(const void* bytes, size_t
 }
 
 template<typename A>
-HllArray<A>* HllSketchImplFactory<A>::newHll(int lgConfigK, TgtHllType tgtHllType, bool startFullSize) {
+HllArray<A>* HllSketchImplFactory<A>::newHll(int lgConfigK, target_hll_type tgtHllType, bool startFullSize) {
   switch (tgtHllType) {
     case HLL_8:
       typedef typename std::allocator_traits<A>::template rebind_alloc<Hll8Array<A>> hll8Alloc;
@@ -123,7 +123,7 @@ HllArray<A>* HllSketchImplFactory<A>::newHll(int lgConfigK, TgtHllType tgtHllTyp
       typedef typename std::allocator_traits<A>::template rebind_alloc<Hll4Array<A>> hll4Alloc;
       return new (hll4Alloc().allocate(1)) Hll4Array<A>(lgConfigK, startFullSize);
   }
-  throw std::logic_error("Invalid TgtHllType");
+  throw std::logic_error("Invalid target_hll_type");
 }
 
 template<typename A>
@@ -154,7 +154,7 @@ Hll4Array<A>* HllSketchImplFactory<A>::convertToHll4(const HllArray<A>& srcHllAr
 
   // 2nd pass: must know curMin.
   // Populate KxQ registers, build AuxHashMap if needed
-  PairIterator_with_deleter<A> itr = srcHllArr.getIterator();
+  pair_iterator_with_deleter<A> itr = srcHllArr.getIterator();
   // nothing allocated, may be null
   AuxHashMap<A>* auxHashMap = srcHllArr.getAuxHashMap();
 
@@ -185,7 +185,7 @@ template<typename A>
 int HllSketchImplFactory<A>::curMinAndNum(const HllArray<A>& hllArr) {
   int curMin = 64;
   int numAtCurMin = 0;
-  PairIterator_with_deleter<A> itr = hllArr.getIterator();
+  pair_iterator_with_deleter<A> itr = hllArr.getIterator();
   while (itr->nextAll()) {
     int v = itr->getValue();
     if (v < curMin) {
@@ -207,7 +207,7 @@ Hll6Array<A>* HllSketchImplFactory<A>::convertToHll6(const HllArray<A>& srcHllAr
   hll6Array->putOutOfOrderFlag(srcHllArr.isOutOfOrderFlag());
 
   int numZeros = 1 << lgConfigK;
-  PairIterator_with_deleter<A> itr = srcHllArr.getIterator();
+  pair_iterator_with_deleter<A> itr = srcHllArr.getIterator();
   while (itr->nextAll()) {
     if (itr->getValue() != HllUtil<A>::EMPTY) {
       --numZeros;
@@ -228,7 +228,7 @@ Hll8Array<A>* HllSketchImplFactory<A>::convertToHll8(const HllArray<A>& srcHllAr
   hll8Array->putOutOfOrderFlag(srcHllArr.isOutOfOrderFlag());
 
   int numZeros = 1 << lgConfigK;
-  PairIterator_with_deleter<A> itr = srcHllArr.getIterator();
+  pair_iterator_with_deleter<A> itr = srcHllArr.getIterator();
   while (itr->nextAll()) {
     if (itr->getValue() != HllUtil<A>::EMPTY) {
       --numZeros;

--- a/hll/include/HllSketchImplFactory.hpp
+++ b/hll/include/HllSketchImplFactory.hpp
@@ -134,7 +134,7 @@ HllSketchImpl<A>* HllSketchImplFactory<A>::reset(HllSketchImpl<A>* impl, bool st
     return hll;
   } else {
     typedef typename std::allocator_traits<A>::template rebind_alloc<CouponList<A>> clAlloc;
-    CouponList<A>* cl = new (clAlloc().allocate(1)) CouponList<A>(impl->getLgConfigK(), impl->getTgtHllType(), CurMode::LIST);
+    CouponList<A>* cl = new (clAlloc().allocate(1)) CouponList<A>(impl->getLgConfigK(), impl->getTgtHllType(), hll_mode::LIST);
     impl->get_deleter()(impl);
     return cl;
   }

--- a/hll/include/HllUnion-internal.hpp
+++ b/hll/include/HllUnion-internal.hpp
@@ -238,7 +238,7 @@ bool hll_union_alloc<A>::is_out_of_order_flag() const {
 }
 
 template<typename A>
-CurMode hll_union_alloc<A>::get_current_mode() const {
+hll_mode hll_union_alloc<A>::get_current_mode() const {
   return gadget.get_current_mode();
 }
 
@@ -270,7 +270,7 @@ double hll_union_alloc<A>::get_rel_err(const bool upper_bound, const bool unione
 
 template<typename A>
 HllSketchImpl<A>* hll_union_alloc<A>::copy_or_downsample(HllSketchImpl<A>* src_impl, const int tgt_lg_k) {
-  if (src_impl->getCurMode() != CurMode::HLL) {
+  if (src_impl->getCurMode() != HLL) {
     throw std::logic_error("Attempt to downsample non-HLL sketch");
   }
   HllArray<A>* src = (HllArray<A>*) src_impl;
@@ -308,14 +308,13 @@ void hll_union_alloc<A>::union_impl(HllSketchImpl<A>* incoming_impl, const int l
   HllSketchImpl<A>* src_impl = incoming_impl; //default
   HllSketchImpl<A>* dstImpl = gadget.sketch_impl; //default
   if ((incoming_impl == nullptr) || incoming_impl->isEmpty()) {
-    return; // gadget.hllSketchImpl;
+    return; // gadget.sketch_impl;
   }
 
   const int hi2bits = (gadget.sketch_impl->isEmpty()) ? 3 : gadget.sketch_impl->getCurMode();
   const int lo2bits = incoming_impl->getCurMode();
 
   const int sw = (hi2bits << 2) | lo2bits;
-  //System.out.println("SW: " + sw);
   switch (sw) {
     case 0: { //src: LIST, gadget: LIST
       pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //LIST

--- a/hll/include/HllUnion-internal.hpp
+++ b/hll/include/HllUnion-internal.hpp
@@ -32,18 +32,18 @@
 namespace datasketches {
 
 template<typename A>
-HllUnion<A>::HllUnion(const int lgMaxK):
+hll_union_alloc<A>::hll_union_alloc(const int lgMaxK):
   lgMaxK(HllUtil<A>::checkLgK(lgMaxK)),
-  gadget(lgMaxK, TgtHllType::HLL_8)
+  gadget(lgMaxK, target_hll_type::HLL_8)
 {}
 
 template<typename A>
-HllUnion<A> HllUnion<A>::deserialize(const void* bytes, size_t len) {
-  HllSketch<A> sk(HllSketch<A>::deserialize(bytes, len));
+hll_union_alloc<A> hll_union_alloc<A>::deserialize(const void* bytes, size_t len) {
+  hll_sketch_alloc<A> sk(hll_sketch_alloc<A>::deserialize(bytes, len));
   // we're using the sketch's lgConfigK to initialize the union so
   // we can initialize the Union with it as long as it's HLL_8.
-  HllUnion<A> hllUnion(sk.getLgConfigK());
-  if (sk.getTgtHllType() == HLL_8) {
+  hll_union_alloc<A> hllUnion(sk.get_lg_config_k());
+  if (sk.get_target_type() == HLL_8) {
     std::swap(hllUnion.gadget.hllSketchImpl, sk.hllSketchImpl);
   } else {
     hllUnion.update(sk);
@@ -52,12 +52,12 @@ HllUnion<A> HllUnion<A>::deserialize(const void* bytes, size_t len) {
 }
 
 template<typename A>
-HllUnion<A> HllUnion<A>::deserialize(std::istream& is) {
-  HllSketch<A> sk(HllSketch<A>::deserialize(is));
+hll_union_alloc<A> hll_union_alloc<A>::deserialize(std::istream& is) {
+  hll_sketch_alloc<A> sk(hll_sketch_alloc<A>::deserialize(is));
   // we're using the sketch's lgConfigK to initialize the union so
   // we can initialize the Union with it as long as it's HLL_8.
-  HllUnion<A> hllUnion(sk.getLgConfigK());
-  if (sk.getTgtHllType() == HLL_8) {    
+  hll_union_alloc<A> hllUnion(sk.get_lg_config_k());
+  if (sk.get_target_type() == HLL_8) {    
     std::swap(hllUnion.gadget.hllSketchImpl, sk.hllSketchImpl);
   } else {
     hllUnion.update(sk);
@@ -66,82 +66,82 @@ HllUnion<A> HllUnion<A>::deserialize(std::istream& is) {
 }
 
 template<typename A>
-static std::ostream& operator<<(std::ostream& os, const HllUnion<A>& hllUnion) {
+static std::ostream& operator<<(std::ostream& os, const hll_union_alloc<A>& hllUnion) {
   return hllUnion.to_string(os, true, true, false, false);
 }
 
 template<typename A>
-HllSketch<A> HllUnion<A>::getResult(TgtHllType tgtHllType) const {
-  return HllSketch<A>(gadget, tgtHllType);
+hll_sketch_alloc<A> hll_union_alloc<A>::get_result(target_hll_type tgtHllType) const {
+  return hll_sketch_alloc<A>(gadget, tgtHllType);
 }
 
 template<typename A>
-void HllUnion<A>::update(const HllSketch<A>& sketch) {
-  unionImpl(static_cast<const HllSketch<A>&>(sketch).hllSketchImpl, lgMaxK);
+void hll_union_alloc<A>::update(const hll_sketch_alloc<A>& sketch) {
+  unionImpl(static_cast<const hll_sketch_alloc<A>&>(sketch).hllSketchImpl, lgMaxK);
 }
 
 template<typename A>
-void HllUnion<A>::update(const std::string& datum) {
+void hll_union_alloc<A>::update(const std::string& datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const uint64_t datum) {
+void hll_union_alloc<A>::update(const uint64_t datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const uint32_t datum) {
+void hll_union_alloc<A>::update(const uint32_t datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const uint16_t datum) {
+void hll_union_alloc<A>::update(const uint16_t datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const uint8_t datum) {
+void hll_union_alloc<A>::update(const uint8_t datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const int64_t datum) {
+void hll_union_alloc<A>::update(const int64_t datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const int32_t datum) {
+void hll_union_alloc<A>::update(const int32_t datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const int16_t datum) {
+void hll_union_alloc<A>::update(const int16_t datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const int8_t datum) {
+void hll_union_alloc<A>::update(const int8_t datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const double datum) {
+void hll_union_alloc<A>::update(const double datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const float datum) {
+void hll_union_alloc<A>::update(const float datum) {
   gadget.update(datum);
 }
 
 template<typename A>
-void HllUnion<A>::update(const void* data, const size_t lengthBytes) {
+void hll_union_alloc<A>::update(const void* data, const size_t lengthBytes) {
   gadget.update(data, lengthBytes);
 }
 
 template<typename A>
-void HllUnion<A>::couponUpdate(const int coupon) {
+void hll_union_alloc<A>::couponUpdate(const int coupon) {
   if (coupon == HllUtil<A>::EMPTY) { return; }
   HllSketchImpl<A>* result = gadget.hllSketchImpl->couponUpdate(coupon);
   if (result != gadget.hllSketchImpl) {
@@ -151,136 +151,136 @@ void HllUnion<A>::couponUpdate(const int coupon) {
 }
 
 template<typename A>
-std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> HllUnion<A>::serializeCompact() const {
-  return gadget.serializeCompact();
+std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> hll_union_alloc<A>::serialize_compact() const {
+  return gadget.serialize_compact();
 }
 
 template<typename A>
-std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> HllUnion<A>::serializeUpdatable() const {
-  return gadget.serializeUpdatable();
+std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> hll_union_alloc<A>::serialize_updatable() const {
+  return gadget.serialize_updatable();
 }
 
 template<typename A>
-void HllUnion<A>::serializeCompact(std::ostream& os) const {
-  return gadget.serializeCompact(os);
+void hll_union_alloc<A>::serialize_compact(std::ostream& os) const {
+  return gadget.serialize_compact(os);
 }
 
 template<typename A>
-void HllUnion<A>::serializeUpdatable(std::ostream& os) const {
-  return gadget.serializeUpdatable(os);
+void hll_union_alloc<A>::serialize_updatable(std::ostream& os) const {
+  return gadget.serialize_updatable(os);
 }
 
 template<typename A>
-std::ostream& HllUnion<A>::to_string(std::ostream& os, const bool summary,
+std::ostream& hll_union_alloc<A>::to_string(std::ostream& os, const bool summary,
                                   const bool detail, const bool auxDetail, const bool all) const {
   return gadget.to_string(os, summary, detail, auxDetail, all);
 }
 
 template<typename A>
-std::string HllUnion<A>::to_string(const bool summary, const bool detail,
+std::string hll_union_alloc<A>::to_string(const bool summary, const bool detail,
                                    const bool auxDetail, const bool all) const {
   return gadget.to_string(summary, detail, auxDetail, all);
 }
 
 template<typename A>
-double HllUnion<A>::getEstimate() const {
-  return gadget.getEstimate();
+double hll_union_alloc<A>::get_estimate() const {
+  return gadget.get_estimate();
 }
 
 template<typename A>
-double HllUnion<A>::getCompositeEstimate() const {
-  return gadget.getCompositeEstimate();
+double hll_union_alloc<A>::get_composite_estimate() const {
+  return gadget.get_composite_estimate();
 }
 
 template<typename A>
-double HllUnion<A>::getLowerBound(const int numStdDev) const {
-  return gadget.getLowerBound(numStdDev);
+double hll_union_alloc<A>::get_lower_bound(const int numStdDev) const {
+  return gadget.get_lower_bound(numStdDev);
 }
 
 template<typename A>
-double HllUnion<A>::getUpperBound(const int numStdDev) const {
-  return gadget.getUpperBound(numStdDev);
+double hll_union_alloc<A>::get_upper_bound(const int numStdDev) const {
+  return gadget.get_upper_bound(numStdDev);
 }
 
 template<typename A>
-int HllUnion<A>::getCompactSerializationBytes() const {
-  return gadget.getCompactSerializationBytes();
+int hll_union_alloc<A>::get_compact_serialization_bytes() const {
+  return gadget.get_compact_serialization_bytes();
 }
 
 template<typename A>
-int HllUnion<A>::getUpdatableSerializationBytes() const {
-  return gadget.getUpdatableSerializationBytes();
+int hll_union_alloc<A>::get_updatable_serialization_bytes() const {
+  return gadget.get_updatable_serialization_bytes();
 }
 
 template<typename A>
-int HllUnion<A>::getLgConfigK() const {
-  return gadget.getLgConfigK();
+int hll_union_alloc<A>::get_lg_config_k() const {
+  return gadget.get_lg_config_k();
 }
 
 template<typename A>
-void HllUnion<A>::reset() {
+void hll_union_alloc<A>::reset() {
   gadget.reset();
 }
 
 template<typename A>
-bool HllUnion<A>::isCompact() const {
-  return gadget.isCompact();
+bool hll_union_alloc<A>::is_compact() const {
+  return gadget.is_compact();
 }
 
 template<typename A>
-bool HllUnion<A>::isEmpty() const {
-  return gadget.isEmpty();
+bool hll_union_alloc<A>::is_empty() const {
+  return gadget.is_empty();
 }
 
 template<typename A>
-bool HllUnion<A>::isOutOfOrderFlag() const {
+bool hll_union_alloc<A>::isOutOfOrderFlag() const {
   return gadget.isOutOfOrderFlag();
 }
 
 template<typename A>
-CurMode HllUnion<A>::getCurrentMode() const {
+CurMode hll_union_alloc<A>::getCurrentMode() const {
   return gadget.getCurrentMode();
 }
 
 template<typename A>
-bool HllUnion<A>::isEstimationMode() const {
+bool hll_union_alloc<A>::isEstimationMode() const {
   return gadget.isEstimationMode();
 }
 
 template<typename A>
-int HllUnion<A>::getSerializationVersion() const {
+int hll_union_alloc<A>::getSerializationVersion() const {
   return HllUtil<A>::SER_VER;
 }
 
 template<typename A>
-TgtHllType HllUnion<A>::getTgtHllType() const {
-  return TgtHllType::HLL_8;
+target_hll_type hll_union_alloc<A>::get_target_type() const {
+  return target_hll_type::HLL_8;
 }
 
 template<typename A>
-int HllUnion<A>::getMaxSerializationBytes(const int lgK) {
-  return HllSketch<A>::getMaxUpdatableSerializationBytes(lgK, TgtHllType::HLL_8);
+int hll_union_alloc<A>::get_max_serialization_bytes(const int lgK) {
+  return hll_sketch_alloc<A>::get_max_updatable_serialization_bytes(lgK, target_hll_type::HLL_8);
 }
 
 template<typename A>
-double HllUnion<A>::getRelErr(const bool upperBound, const bool unioned,
+double hll_union_alloc<A>::get_rel_err(const bool upperBound, const bool unioned,
                            const int lgConfigK, const int numStdDev) {
   return HllUtil<A>::getRelErr(upperBound, unioned, lgConfigK, numStdDev);
 }
 
 template<typename A>
-HllSketchImpl<A>* HllUnion<A>::copyOrDownsampleHll(HllSketchImpl<A>* srcImpl, const int tgtLgK) {
+HllSketchImpl<A>* hll_union_alloc<A>::copyOrDownsampleHll(HllSketchImpl<A>* srcImpl, const int tgtLgK) {
   if (srcImpl->getCurMode() != CurMode::HLL) {
     throw std::logic_error("Attempt to downsample non-HLL sketch");
   }
   HllArray<A>* src = (HllArray<A>*) srcImpl;
   const int srcLgK = src->getLgConfigK();
-  if ((srcLgK <= tgtLgK) && (src->getTgtHllType() == TgtHllType::HLL_8)) {
+  if ((srcLgK <= tgtLgK) && (src->getTgtHllType() == target_hll_type::HLL_8)) {
     return src->copy();
   }
   const int minLgK = ((srcLgK < tgtLgK) ? srcLgK : tgtLgK);
-  HllArray<A>* tgtHllArr = HllSketchImplFactory<A>::newHll(minLgK, TgtHllType::HLL_8);
-  PairIterator_with_deleter<A> srcItr = src->getIterator();
+  HllArray<A>* tgtHllArr = HllSketchImplFactory<A>::newHll(minLgK, target_hll_type::HLL_8);
+  pair_iterator_with_deleter<A> srcItr = src->getIterator();
   while (srcItr->nextValid()) {
     tgtHllArr->couponUpdate(srcItr->getPair());
   }
@@ -292,7 +292,7 @@ HllSketchImpl<A>* HllUnion<A>::copyOrDownsampleHll(HllSketchImpl<A>* srcImpl, co
 }
 
 template<typename A>
-inline HllSketchImpl<A>* HllUnion<A>::leakFreeCouponUpdate(HllSketchImpl<A>* impl, const int coupon) {
+inline HllSketchImpl<A>* hll_union_alloc<A>::leakFreeCouponUpdate(HllSketchImpl<A>* impl, const int coupon) {
   HllSketchImpl<A>* result = impl->couponUpdate(coupon);
   if (result != impl) {
     impl->get_deleter()(impl);
@@ -301,8 +301,8 @@ inline HllSketchImpl<A>* HllUnion<A>::leakFreeCouponUpdate(HllSketchImpl<A>* imp
 }
 
 template<typename A>
-void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
-  if (gadget.hllSketchImpl->getTgtHllType() != TgtHllType::HLL_8) {
+void hll_union_alloc<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
+  if (gadget.hllSketchImpl->getTgtHllType() != target_hll_type::HLL_8) {
     throw std::logic_error("Must call unionImpl() with HLL_8 input");
   }
   HllSketchImpl<A>* srcImpl = incomingImpl; //default
@@ -318,7 +318,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
   //System.out.println("SW: " + sw);
   switch (sw) {
     case 0: { //src: LIST, gadget: LIST
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -329,7 +329,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
     }
     case 1: { //src: SET, gadget: LIST
       //consider a swap here
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -342,7 +342,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
       //use lgMaxK because LIST has effective K of 2^26
       srcImpl = gadget.hllSketchImpl;
       dstImpl = copyOrDownsampleHll(incomingImpl, lgMaxK);
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator();
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator();
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -353,7 +353,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
       break;
     }
     case 4: { //src: LIST, gadget: SET
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -362,7 +362,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
       break;
     }
     case 5: { //src: SET, gadget: SET
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -375,7 +375,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
       //use lgMaxK because LIST has effective K of 2^26
       srcImpl = gadget.hllSketchImpl;
       dstImpl = copyOrDownsampleHll(incomingImpl, lgMaxK);
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
       if (dstImpl->getCurMode() != HLL) {
         throw std::logic_error("dstImpl must be in HLL mode");
       }
@@ -391,7 +391,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
       if (dstImpl->getCurMode() != HLL) {
         throw std::logic_error("dstImpl must be in HLL mode");
       }
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -408,7 +408,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
       if (dstImpl->getCurMode() != HLL) {
         throw std::logic_error("dstImpl must be in HLL mode");
       }
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -429,7 +429,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
         // always replaces gadget
         gadget.hllSketchImpl->get_deleter()(gadget.hllSketchImpl);
       }
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //HLL
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //HLL
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -438,7 +438,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
       break;
     }
     case 12: { //src: LIST, gadget: empty
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }
@@ -447,7 +447,7 @@ void HllUnion<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
       break;
     }
     case 13: { //src: SET, gadget: empty
-      PairIterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
+      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
       while (srcItr->nextValid()) {
         dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
       }

--- a/hll/include/HllUnion-internal.hpp
+++ b/hll/include/HllUnion-internal.hpp
@@ -32,19 +32,19 @@
 namespace datasketches {
 
 template<typename A>
-hll_union_alloc<A>::hll_union_alloc(const int lgMaxK):
-  lgMaxK(HllUtil<A>::checkLgK(lgMaxK)),
-  gadget(lgMaxK, target_hll_type::HLL_8)
+hll_union_alloc<A>::hll_union_alloc(const int lg_max_k):
+  lg_max_k(HllUtil<A>::checkLgK(lg_max_k)),
+  gadget(lg_max_k, target_hll_type::HLL_8)
 {}
 
 template<typename A>
 hll_union_alloc<A> hll_union_alloc<A>::deserialize(const void* bytes, size_t len) {
   hll_sketch_alloc<A> sk(hll_sketch_alloc<A>::deserialize(bytes, len));
-  // we're using the sketch's lgConfigK to initialize the union so
+  // we're using the sketch's lg_config_k to initialize the union so
   // we can initialize the Union with it as long as it's HLL_8.
   hll_union_alloc<A> hllUnion(sk.get_lg_config_k());
   if (sk.get_target_type() == HLL_8) {
-    std::swap(hllUnion.gadget.hllSketchImpl, sk.hllSketchImpl);
+    std::swap(hllUnion.gadget.sketch_impl, sk.sketch_impl);
   } else {
     hllUnion.update(sk);
   }
@@ -54,11 +54,11 @@ hll_union_alloc<A> hll_union_alloc<A>::deserialize(const void* bytes, size_t len
 template<typename A>
 hll_union_alloc<A> hll_union_alloc<A>::deserialize(std::istream& is) {
   hll_sketch_alloc<A> sk(hll_sketch_alloc<A>::deserialize(is));
-  // we're using the sketch's lgConfigK to initialize the union so
+  // we're using the sketch's lg_config_k to initialize the union so
   // we can initialize the Union with it as long as it's HLL_8.
   hll_union_alloc<A> hllUnion(sk.get_lg_config_k());
   if (sk.get_target_type() == HLL_8) {    
-    std::swap(hllUnion.gadget.hllSketchImpl, sk.hllSketchImpl);
+    std::swap(hllUnion.gadget.sketch_impl, sk.sketch_impl);
   } else {
     hllUnion.update(sk);
   }
@@ -71,13 +71,13 @@ static std::ostream& operator<<(std::ostream& os, const hll_union_alloc<A>& hllU
 }
 
 template<typename A>
-hll_sketch_alloc<A> hll_union_alloc<A>::get_result(target_hll_type tgtHllType) const {
-  return hll_sketch_alloc<A>(gadget, tgtHllType);
+hll_sketch_alloc<A> hll_union_alloc<A>::get_result(target_hll_type target_type) const {
+  return hll_sketch_alloc<A>(gadget, target_type);
 }
 
 template<typename A>
 void hll_union_alloc<A>::update(const hll_sketch_alloc<A>& sketch) {
-  unionImpl(static_cast<const hll_sketch_alloc<A>&>(sketch).hllSketchImpl, lgMaxK);
+  union_impl(static_cast<const hll_sketch_alloc<A>&>(sketch).sketch_impl, lg_max_k);
 }
 
 template<typename A>
@@ -136,17 +136,17 @@ void hll_union_alloc<A>::update(const float datum) {
 }
 
 template<typename A>
-void hll_union_alloc<A>::update(const void* data, const size_t lengthBytes) {
-  gadget.update(data, lengthBytes);
+void hll_union_alloc<A>::update(const void* data, const size_t length_bytes) {
+  gadget.update(data, length_bytes);
 }
 
 template<typename A>
-void hll_union_alloc<A>::couponUpdate(const int coupon) {
+void hll_union_alloc<A>::coupon_update(const int coupon) {
   if (coupon == HllUtil<A>::EMPTY) { return; }
-  HllSketchImpl<A>* result = gadget.hllSketchImpl->couponUpdate(coupon);
-  if (result != gadget.hllSketchImpl) {
-    if (gadget.hllSketchImpl != nullptr) { gadget.hllSketchImpl->get_deleter()(gadget.hllSketchImpl); }
-    gadget.hllSketchImpl = result;
+  HllSketchImpl<A>* result = gadget.sketch_impl->coupon_update(coupon);
+  if (result != gadget.sketch_impl) {
+    if (gadget.sketch_impl != nullptr) { gadget.sketch_impl->get_deleter()(gadget.sketch_impl); }
+    gadget.sketch_impl = result;
   }
 }
 
@@ -172,14 +172,14 @@ void hll_union_alloc<A>::serialize_updatable(std::ostream& os) const {
 
 template<typename A>
 std::ostream& hll_union_alloc<A>::to_string(std::ostream& os, const bool summary,
-                                  const bool detail, const bool auxDetail, const bool all) const {
-  return gadget.to_string(os, summary, detail, auxDetail, all);
+                                  const bool detail, const bool aux_detail, const bool all) const {
+  return gadget.to_string(os, summary, detail, aux_detail, all);
 }
 
 template<typename A>
 std::string hll_union_alloc<A>::to_string(const bool summary, const bool detail,
-                                   const bool auxDetail, const bool all) const {
-  return gadget.to_string(summary, detail, auxDetail, all);
+                                   const bool aux_detail, const bool all) const {
+  return gadget.to_string(summary, detail, aux_detail, all);
 }
 
 template<typename A>
@@ -193,13 +193,13 @@ double hll_union_alloc<A>::get_composite_estimate() const {
 }
 
 template<typename A>
-double hll_union_alloc<A>::get_lower_bound(const int numStdDev) const {
-  return gadget.get_lower_bound(numStdDev);
+double hll_union_alloc<A>::get_lower_bound(const int num_std_dev) const {
+  return gadget.get_lower_bound(num_std_dev);
 }
 
 template<typename A>
-double hll_union_alloc<A>::get_upper_bound(const int numStdDev) const {
-  return gadget.get_upper_bound(numStdDev);
+double hll_union_alloc<A>::get_upper_bound(const int num_std_dev) const {
+  return gadget.get_upper_bound(num_std_dev);
 }
 
 template<typename A>
@@ -233,22 +233,22 @@ bool hll_union_alloc<A>::is_empty() const {
 }
 
 template<typename A>
-bool hll_union_alloc<A>::isOutOfOrderFlag() const {
-  return gadget.isOutOfOrderFlag();
+bool hll_union_alloc<A>::is_out_of_order_flag() const {
+  return gadget.is_out_of_order_flag();
 }
 
 template<typename A>
-CurMode hll_union_alloc<A>::getCurrentMode() const {
-  return gadget.getCurrentMode();
+CurMode hll_union_alloc<A>::get_current_mode() const {
+  return gadget.get_current_mode();
 }
 
 template<typename A>
-bool hll_union_alloc<A>::isEstimationMode() const {
-  return gadget.isEstimationMode();
+bool hll_union_alloc<A>::is_estimation_mode() const {
+  return gadget.is_estimation_mode();
 }
 
 template<typename A>
-int hll_union_alloc<A>::getSerializationVersion() const {
+int hll_union_alloc<A>::get_serialization_version() const {
   return HllUtil<A>::SER_VER;
 }
 
@@ -258,27 +258,27 @@ target_hll_type hll_union_alloc<A>::get_target_type() const {
 }
 
 template<typename A>
-int hll_union_alloc<A>::get_max_serialization_bytes(const int lgK) {
-  return hll_sketch_alloc<A>::get_max_updatable_serialization_bytes(lgK, target_hll_type::HLL_8);
+int hll_union_alloc<A>::get_max_serialization_bytes(const int lg_k) {
+  return hll_sketch_alloc<A>::get_max_updatable_serialization_bytes(lg_k, target_hll_type::HLL_8);
 }
 
 template<typename A>
-double hll_union_alloc<A>::get_rel_err(const bool upperBound, const bool unioned,
-                           const int lgConfigK, const int numStdDev) {
-  return HllUtil<A>::getRelErr(upperBound, unioned, lgConfigK, numStdDev);
+double hll_union_alloc<A>::get_rel_err(const bool upper_bound, const bool unioned,
+                           const int lg_config_k, const int num_std_dev) {
+  return HllUtil<A>::getRelErr(upper_bound, unioned, lg_config_k, num_std_dev);
 }
 
 template<typename A>
-HllSketchImpl<A>* hll_union_alloc<A>::copyOrDownsampleHll(HllSketchImpl<A>* srcImpl, const int tgtLgK) {
-  if (srcImpl->getCurMode() != CurMode::HLL) {
+HllSketchImpl<A>* hll_union_alloc<A>::copy_or_downsample(HllSketchImpl<A>* src_impl, const int tgt_lg_k) {
+  if (src_impl->getCurMode() != CurMode::HLL) {
     throw std::logic_error("Attempt to downsample non-HLL sketch");
   }
-  HllArray<A>* src = (HllArray<A>*) srcImpl;
-  const int srcLgK = src->getLgConfigK();
-  if ((srcLgK <= tgtLgK) && (src->getTgtHllType() == target_hll_type::HLL_8)) {
+  HllArray<A>* src = (HllArray<A>*) src_impl;
+  const int src_lg_k = src->getLgConfigK();
+  if ((src_lg_k <= tgt_lg_k) && (src->getTgtHllType() == target_hll_type::HLL_8)) {
     return src->copy();
   }
-  const int minLgK = ((srcLgK < tgtLgK) ? srcLgK : tgtLgK);
+  const int minLgK = ((src_lg_k < tgt_lg_k) ? src_lg_k : tgt_lg_k);
   HllArray<A>* tgtHllArr = HllSketchImplFactory<A>::newHll(minLgK, target_hll_type::HLL_8);
   pair_iterator_with_deleter<A> srcItr = src->getIterator();
   while (srcItr->nextValid()) {
@@ -292,7 +292,7 @@ HllSketchImpl<A>* hll_union_alloc<A>::copyOrDownsampleHll(HllSketchImpl<A>* srcI
 }
 
 template<typename A>
-inline HllSketchImpl<A>* hll_union_alloc<A>::leakFreeCouponUpdate(HllSketchImpl<A>* impl, const int coupon) {
+inline HllSketchImpl<A>* hll_union_alloc<A>::leak_free_coupon_update(HllSketchImpl<A>* impl, const int coupon) {
   HllSketchImpl<A>* result = impl->couponUpdate(coupon);
   if (result != impl) {
     impl->get_deleter()(impl);
@@ -301,37 +301,37 @@ inline HllSketchImpl<A>* hll_union_alloc<A>::leakFreeCouponUpdate(HllSketchImpl<
 }
 
 template<typename A>
-void hll_union_alloc<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgMaxK) {
-  if (gadget.hllSketchImpl->getTgtHllType() != target_hll_type::HLL_8) {
+void hll_union_alloc<A>::union_impl(HllSketchImpl<A>* incoming_impl, const int lg_max_k) {
+  if (gadget.sketch_impl->getTgtHllType() != target_hll_type::HLL_8) {
     throw std::logic_error("Must call unionImpl() with HLL_8 input");
   }
-  HllSketchImpl<A>* srcImpl = incomingImpl; //default
-  HllSketchImpl<A>* dstImpl = gadget.hllSketchImpl; //default
-  if ((incomingImpl == nullptr) || incomingImpl->isEmpty()) {
+  HllSketchImpl<A>* src_impl = incoming_impl; //default
+  HllSketchImpl<A>* dstImpl = gadget.sketch_impl; //default
+  if ((incoming_impl == nullptr) || incoming_impl->isEmpty()) {
     return; // gadget.hllSketchImpl;
   }
 
-  const int hi2bits = (gadget.hllSketchImpl->isEmpty()) ? 3 : gadget.hllSketchImpl->getCurMode();
-  const int lo2bits = incomingImpl->getCurMode();
+  const int hi2bits = (gadget.sketch_impl->isEmpty()) ? 3 : gadget.sketch_impl->getCurMode();
+  const int lo2bits = incoming_impl->getCurMode();
 
   const int sw = (hi2bits << 2) | lo2bits;
   //System.out.println("SW: " + sw);
   switch (sw) {
     case 0: { //src: LIST, gadget: LIST
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //LIST
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       //whichever is True wins:
-      dstImpl->putOutOfOrderFlag(dstImpl->isOutOfOrderFlag() | srcImpl->isOutOfOrderFlag());
+      dstImpl->putOutOfOrderFlag(dstImpl->isOutOfOrderFlag() | src_impl->isOutOfOrderFlag());
       // gadget: cleanly updated as needed
       break;
     }
     case 1: { //src: SET, gadget: LIST
       //consider a swap here
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //SET
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       dstImpl->putOutOfOrderFlag(true); //SET oooFlag is always true
       // gadget: cleanly updated as needed
@@ -339,32 +339,32 @@ void hll_union_alloc<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgM
     }
     case 2: { //src: HLL, gadget: LIST
       //swap so that src is gadget-LIST, tgt is HLL
-      //use lgMaxK because LIST has effective K of 2^26
-      srcImpl = gadget.hllSketchImpl;
-      dstImpl = copyOrDownsampleHll(incomingImpl, lgMaxK);
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator();
+      //use lg_max_k because LIST has effective K of 2^26
+      src_impl = gadget.sketch_impl;
+      dstImpl = copy_or_downsample(incoming_impl, lg_max_k);
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator();
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       //whichever is True wins:
-      dstImpl->putOutOfOrderFlag(srcImpl->isOutOfOrderFlag() | dstImpl->isOutOfOrderFlag());
+      dstImpl->putOutOfOrderFlag(src_impl->isOutOfOrderFlag() | dstImpl->isOutOfOrderFlag());
       // gadget: swapped, replacing with new impl
-      gadget.hllSketchImpl->get_deleter()(gadget.hllSketchImpl);
+      gadget.sketch_impl->get_deleter()(gadget.sketch_impl);
       break;
     }
     case 4: { //src: LIST, gadget: SET
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //LIST
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       dstImpl->putOutOfOrderFlag(true); //SET oooFlag is always true
       // gadget: cleanly updated as needed
       break;
     }
     case 5: { //src: SET, gadget: SET
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //SET
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       dstImpl->putOutOfOrderFlag(true); //SET oooFlag is always true
       // gadget: cleanly updated as needed
@@ -372,33 +372,33 @@ void hll_union_alloc<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgM
     }
     case 6: { //src: HLL, gadget: SET
       //swap so that src is gadget-SET, tgt is HLL
-      //use lgMaxK because LIST has effective K of 2^26
-      srcImpl = gadget.hllSketchImpl;
-      dstImpl = copyOrDownsampleHll(incomingImpl, lgMaxK);
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      //use lg_max_k because LIST has effective K of 2^26
+      src_impl = gadget.sketch_impl;
+      dstImpl = copy_or_downsample(incoming_impl, lg_max_k);
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //LIST
       if (dstImpl->getCurMode() != HLL) {
         throw std::logic_error("dstImpl must be in HLL mode");
       }
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       dstImpl->putOutOfOrderFlag(true); //merging SET into non-empty HLL -> true
       // gadget: swapped, replacing with new impl
-      gadget.hllSketchImpl->get_deleter()(gadget.hllSketchImpl);
+      gadget.sketch_impl->get_deleter()(gadget.sketch_impl);
       break;
     }
     case 8: { //src: LIST, gadget: HLL
       if (dstImpl->getCurMode() != HLL) {
         throw std::logic_error("dstImpl must be in HLL mode");
       }
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //LIST
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       //whichever is True wins:
-      dstImpl->putOutOfOrderFlag(dstImpl->isOutOfOrderFlag() | srcImpl->isOutOfOrderFlag());
+      dstImpl->putOutOfOrderFlag(dstImpl->isOutOfOrderFlag() | src_impl->isOutOfOrderFlag());
       // gadget: should remain unchanged
-      if (dstImpl != gadget.hllSketchImpl) {
+      if (dstImpl != gadget.sketch_impl) {
         // should not have changed from HLL
         throw std::logic_error("dstImpl unepxectedly changed from gadget");
       } 
@@ -408,63 +408,63 @@ void hll_union_alloc<A>::unionImpl(HllSketchImpl<A>* incomingImpl, const int lgM
       if (dstImpl->getCurMode() != HLL) {
         throw std::logic_error("dstImpl must be in HLL mode");
       }
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //SET
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       dstImpl->putOutOfOrderFlag(true); //merging SET into existing HLL -> true
       // gadget: should remain unchanged
-      if (dstImpl != gadget.hllSketchImpl) {
+      if (dstImpl != gadget.sketch_impl) {
         // should not have changed from HLL
         throw std::logic_error("dstImpl unepxectedly changed from gadget");
       } 
       break;
     }
     case 10: { //src: HLL, gadget: HLL
-      const int srcLgK = srcImpl->getLgConfigK();
+      const int src_lg_k = src_impl->getLgConfigK();
       const int dstLgK = dstImpl->getLgConfigK();
-      const int minLgK = ((srcLgK < dstLgK) ? srcLgK : dstLgK);
-      if ((srcLgK < dstLgK) || (dstImpl->getTgtHllType() != HLL_8)) {
-        dstImpl = copyOrDownsampleHll(dstImpl, minLgK);
+      const int minLgK = ((src_lg_k < dstLgK) ? src_lg_k : dstLgK);
+      if ((src_lg_k < dstLgK) || (dstImpl->getTgtHllType() != HLL_8)) {
+        dstImpl = copy_or_downsample(dstImpl, minLgK);
         // always replaces gadget
-        gadget.hllSketchImpl->get_deleter()(gadget.hllSketchImpl);
+        gadget.sketch_impl->get_deleter()(gadget.sketch_impl);
       }
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //HLL
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //HLL
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       dstImpl->putOutOfOrderFlag(true); //union of two HLL modes is always true
       // gadget: replaced if copied/downampled, otherwise should be unchanged
       break;
     }
     case 12: { //src: LIST, gadget: empty
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //LIST
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //LIST
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
-      dstImpl->putOutOfOrderFlag(srcImpl->isOutOfOrderFlag()); //whatever source is
+      dstImpl->putOutOfOrderFlag(src_impl->isOutOfOrderFlag()); //whatever source is
       // gadget: cleanly updated as needed
       break;
     }
     case 13: { //src: SET, gadget: empty
-      pair_iterator_with_deleter<A> srcItr = srcImpl->getIterator(); //SET
+      pair_iterator_with_deleter<A> srcItr = src_impl->getIterator(); //SET
       while (srcItr->nextValid()) {
-        dstImpl = leakFreeCouponUpdate(dstImpl, srcItr->getPair()); //assignment required
+        dstImpl = leak_free_coupon_update(dstImpl, srcItr->getPair()); //assignment required
       }
       dstImpl->putOutOfOrderFlag(true); //SET oooFlag is always true
       // gadget: cleanly updated as needed
       break;
     }
     case 14: { //src: HLL, gadget: empty
-      dstImpl = copyOrDownsampleHll(srcImpl, lgMaxK);
-      dstImpl->putOutOfOrderFlag(srcImpl->isOutOfOrderFlag()); //whatever source is.
+      dstImpl = copy_or_downsample(src_impl, lg_max_k);
+      dstImpl->putOutOfOrderFlag(src_impl->isOutOfOrderFlag()); //whatever source is.
       // gadget: always replaced with copied/downsampled sketch
-      gadget.hllSketchImpl->get_deleter()(gadget.hllSketchImpl);
+      gadget.sketch_impl->get_deleter()(gadget.sketch_impl);
       break;
     }
   }
   
-  gadget.hllSketchImpl = dstImpl;
+  gadget.sketch_impl = dstImpl;
 }
 
 }

--- a/hll/include/HllUtil.hpp
+++ b/hll/include/HllUtil.hpp
@@ -30,7 +30,7 @@
 
 namespace datasketches {
 
-enum CurMode { LIST = 0, SET, HLL };
+enum hll_mode { LIST = 0, SET, HLL };
 
 // template provides internal consistency and allows static float values
 // but we don't use the template parameter anywhere
@@ -120,7 +120,7 @@ public:
   static unsigned int simpleIntLog2(unsigned int n); // n must be power of 2
   static unsigned int getNumberOfLeadingZeros(uint64_t x);
   static unsigned int numberOfTrailingZeros(uint32_t n);
-  static int computeLgArrInts(CurMode mode, int count, int lgConfigK);
+  static int computeLgArrInts(hll_mode mode, int count, int lgConfigK);
   static double getRelErr(bool upperBound, bool unioned,
                           int lgConfigK, int numStdDev);
 };
@@ -272,7 +272,7 @@ inline unsigned int HllUtil<A>::numberOfTrailingZeros(uint32_t v) {
 }
 
 template<typename A>
-inline int HllUtil<A>::computeLgArrInts(CurMode mode, int count, int lgConfigK) {
+inline int HllUtil<A>::computeLgArrInts(hll_mode mode, int count, int lgConfigK) {
   // assume value missing and recompute
   if (mode == LIST) { return HllUtil<A>::LG_INIT_LIST_SIZE; }
   int ceilPwr2 = HllUtil<A>::ceilingPowerOf2(count);

--- a/hll/include/PairIterator.hpp
+++ b/hll/include/PairIterator.hpp
@@ -46,7 +46,7 @@ class PairIterator {
 };
 
 template<typename A = std::allocator<char>>
-using PairIterator_with_deleter = std::unique_ptr<PairIterator<A>, std::function<void(PairIterator<A>*)>>;
+using pair_iterator_with_deleter = std::unique_ptr<PairIterator<A>, std::function<void(PairIterator<A>*)>>;
 
 }
 

--- a/hll/include/hll.hpp
+++ b/hll/include/hll.hpp
@@ -126,7 +126,7 @@ class hll_sketch_alloc final {
     std::string type_as_string() const;
     std::string mode_as_string() const;
 
-    CurMode get_current_mode() const;
+    hll_mode get_current_mode() const;
     int get_serialization_version() const;
     bool is_out_of_order_flag() const;
     bool is_estimation_mode() const;
@@ -215,12 +215,12 @@ class hll_union_alloc {
 
     void coupon_update(int coupon);
 
-    CurMode get_current_mode() const;
+    hll_mode get_current_mode() const;
     int get_serialization_version() const;
     bool is_out_of_order_flag() const;
     bool is_estimation_mode() const;
 
-    // calls couponUpdate on sketch, freeing the old sketch upon changes in CurMode
+    // calls couponUpdate on sketch, freeing the old sketch upon changes in hll_mode
     static HllSketchImpl<A>* leak_free_coupon_update(HllSketchImpl<A>* impl, int coupon);
 
     int lg_max_k;

--- a/hll/include/hll.hpp
+++ b/hll/include/hll.hpp
@@ -121,20 +121,20 @@ class hll_sketch_alloc final {
   private:
     explicit hll_sketch_alloc(HllSketchImpl<A>* that);
 
-    void couponUpdate(int coupon);
+    void coupon_update(int coupon);
 
-    std::string typeAsString() const;
-    std::string modeAsString() const;
+    std::string type_as_string() const;
+    std::string mode_as_string() const;
 
-    CurMode getCurrentMode() const;
-    int getSerializationVersion() const;
-    bool isOutOfOrderFlag() const;
-    bool isEstimationMode() const;
+    CurMode get_current_mode() const;
+    int get_serialization_version() const;
+    bool is_out_of_order_flag() const;
+    bool is_estimation_mode() const;
 
     typedef typename std::allocator_traits<A>::template rebind_alloc<hll_sketch_alloc> AllocHllSketch;
     friend AllocHllSketch;
 
-    HllSketchImpl<A>* hllSketchImpl;
+    HllSketchImpl<A>* sketch_impl;
     friend hll_union_alloc<A>;
 };
 
@@ -204,28 +204,26 @@ class hll_union_alloc {
     * perform the union. This may involve swapping, down-sampling, transforming, and / or
     * copying one of the arguments and may completely replace the internals of the union.
     *
-    * @param incomingImpl the given incoming sketch, which may not be modified.
-    * @param gadgetImpl the given gadget sketch, which must have a target of HLL_8 and may be
-    * modified.
-    * @param lgMaxK the maximum value of log2 K for this union.
+    * @param incoming_impl the given incoming sketch, which may not be modified.
+    * @param lg_max_k the maximum value of log2 K for this union.
     * //@return the union of the two sketches in the form of the internal HllSketchImpl, which for
     * //the union is always in HLL_8 form.
     */
-    void unionImpl(HllSketchImpl<A>* incomingImpl, int lgMaxK);
+    void union_impl(HllSketchImpl<A>* incoming_impl, int lg_max_k);
 
-    static HllSketchImpl<A>* copyOrDownsampleHll(HllSketchImpl<A>* srcImpl, int tgtLgK);
+    static HllSketchImpl<A>* copy_or_downsample(HllSketchImpl<A>* src_impl, int tgt_lg_k);
 
-    void couponUpdate(int coupon);
+    void coupon_update(int coupon);
 
-    CurMode getCurrentMode() const;
-    int getSerializationVersion() const;
-    bool isOutOfOrderFlag() const;
-    bool isEstimationMode() const;
+    CurMode get_current_mode() const;
+    int get_serialization_version() const;
+    bool is_out_of_order_flag() const;
+    bool is_estimation_mode() const;
 
     // calls couponUpdate on sketch, freeing the old sketch upon changes in CurMode
-    static HllSketchImpl<A>* leakFreeCouponUpdate(HllSketchImpl<A>* impl, int coupon);
+    static HllSketchImpl<A>* leak_free_coupon_update(HllSketchImpl<A>* impl, int coupon);
 
-    int lgMaxK;
+    int lg_max_k;
     hll_sketch_alloc<A> gadget;
 
 };

--- a/hll/include/hll.hpp
+++ b/hll/include/hll.hpp
@@ -29,7 +29,7 @@
 namespace datasketches {
 
 // The different types of HLL sketches
-enum TgtHllType {
+enum target_hll_type {
     HLL_4,
     HLL_6,
     HLL_8
@@ -39,40 +39,40 @@ template<typename A>
 class HllSketchImpl;
 
 template<typename A>
-class HllUnion;
+class hll_union_alloc;
 
 using byte_ptr_with_deleter = std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>;
 
 template<typename A = std::allocator<char> >
-class HllSketch final {
+class hll_sketch_alloc final {
   public:
-    explicit HllSketch(int lgConfigK, TgtHllType tgtHllType = HLL_4, bool startFullSize = false);
-    static HllSketch deserialize(std::istream& is);
-    static HllSketch deserialize(const void* bytes, size_t len);
-    HllSketch(const HllSketch<A>& that);
-    HllSketch(const HllSketch<A>& that, TgtHllType tgtHllType);
-    HllSketch(HllSketch<A>&& that) noexcept;
+    explicit hll_sketch_alloc(int lg_config_k, target_hll_type tgt_type = HLL_4, bool start_full_size = false);
+    static hll_sketch_alloc deserialize(std::istream& is);
+    static hll_sketch_alloc deserialize(const void* bytes, size_t len);
+    hll_sketch_alloc(const hll_sketch_alloc<A>& that);
+    hll_sketch_alloc(const hll_sketch_alloc<A>& that, target_hll_type tgt_type);
+    hll_sketch_alloc(hll_sketch_alloc<A>&& that) noexcept;
 
-    ~HllSketch();
+    ~hll_sketch_alloc();
 
-    HllSketch operator=(const HllSketch<A>& other);
-    HllSketch operator=(HllSketch<A>&& other);
+    hll_sketch_alloc operator=(const hll_sketch_alloc<A>& other);
+    hll_sketch_alloc operator=(hll_sketch_alloc<A>&& other);
 
     void reset();
     
-    std::pair<byte_ptr_with_deleter, const size_t> serializeCompact(unsigned header_size_bytes = 0) const;
-    std::pair<byte_ptr_with_deleter, const size_t> serializeUpdatable() const;
-    void serializeCompact(std::ostream& os) const;
-    void serializeUpdatable(std::ostream& os) const;
+    std::pair<byte_ptr_with_deleter, const size_t> serialize_compact(unsigned header_size_bytes = 0) const;
+    std::pair<byte_ptr_with_deleter, const size_t> serialize_updatable() const;
+    void serialize_compact(std::ostream& os) const;
+    void serialize_updatable(std::ostream& os) const;
     
     std::ostream& to_string(std::ostream& os,
                             bool summary = true,
                             bool detail = false,
-                            bool auxDetail = false,
+                            bool aux_detail = false,
                             bool all = false) const;
     std::string to_string(bool summary = true,
                           bool detail = false,
-                          bool auxDetail = false,
+                          bool aux_detail = false,
                           bool all = false) const;                                    
 
     void update(const std::string& datum);
@@ -86,41 +86,40 @@ class HllSketch final {
     void update(int8_t datum);
     void update(double datum);
     void update(float datum);
-    void update(const void* data, size_t lengthBytes);
+    void update(const void* data, size_t length_bytes);
 
-    double getEstimate() const;
-    double getCompositeEstimate() const;
-    double getLowerBound(int numStdDev) const;
-    double getUpperBound(int numStdDev) const;
+    double get_estimate() const;
+    double get_composite_estimate() const;
+    double get_lower_bound(int num_std_dev) const;
+    double get_upper_bound(int num_std_dev) const;
 
-    int getLgConfigK() const;
-    TgtHllType getTgtHllType() const;
+    int get_lg_config_k() const;
+    target_hll_type get_target_type() const;
 
-    bool isCompact() const;
-    bool isEmpty() const;
+    bool is_compact() const;
+    bool is_empty() const;
 
-    int getUpdatableSerializationBytes() const;
-    int getCompactSerializationBytes() const;
+    int get_updatable_serialization_bytes() const;
+    int get_compact_serialization_bytes() const;
 
     /**
-     * Returns the maximum size in bytes that this sketch can grow to given lgConfigK.
+     * Returns the maximum size in bytes that this sketch can grow to given lg_config_k.
      * However, for the HLL_4 sketch type, this value can be exceeded in extremely rare cases.
      * If exceeded, it will be larger by only a few percent.
      *
-     * @param lgConfigK The Log2 of K for the target HLL sketch. This value must be
+     * @param lg_config_k The Log2 of K for the target HLL sketch. This value must be
      * between 4 and 21 inclusively.
-     * @param tgtHllType the desired Hll type
+     * @param tgt_type the desired Hll type
      * @return the maximum size in bytes that this sketch can grow to.
      */
-    static int getMaxUpdatableSerializationBytes(int lgK, TgtHllType tgtHllType);
-    static double getRelErr(bool upperBound, bool unioned,
-                            int lgConfigK, int numStdDev);
+    static int get_max_updatable_serialization_bytes(int lg_k, target_hll_type tgt_type);
+    static double get_rel_err(bool upper_bound, bool unioned,
+                              int lg_config_k, int num_std_dev);
 
-    //std::unique_ptr<PairIterator<A>> getIterator() const;
-    PairIterator_with_deleter<A> getIterator() const;
+    pair_iterator_with_deleter<A> get_iterator() const;
 
   private:
-    explicit HllSketch(HllSketchImpl<A>* that);
+    explicit hll_sketch_alloc(HllSketchImpl<A>* that);
 
     void couponUpdate(int coupon);
 
@@ -132,54 +131,54 @@ class HllSketch final {
     bool isOutOfOrderFlag() const;
     bool isEstimationMode() const;
 
-    typedef typename std::allocator_traits<A>::template rebind_alloc<HllSketch> AllocHllSketch;
+    typedef typename std::allocator_traits<A>::template rebind_alloc<hll_sketch_alloc> AllocHllSketch;
     friend AllocHllSketch;
 
     HllSketchImpl<A>* hllSketchImpl;
-    friend HllUnion<A>;
+    friend hll_union_alloc<A>;
 };
 
 template<typename A = std::allocator<char> >
-class HllUnion {
+class hll_union_alloc {
   public:
-    explicit HllUnion(int lgMaxK);
+    explicit hll_union_alloc(int lg_max_k);
 
-    static HllUnion deserialize(std::istream& is);
-    static HllUnion deserialize(const void* bytes, size_t len);
+    static hll_union_alloc deserialize(std::istream& is);
+    static hll_union_alloc deserialize(const void* bytes, size_t len);
 
-    double getEstimate() const;
-    double getCompositeEstimate() const;
-    double getLowerBound(int numStdDev) const;
-    double getUpperBound(int numStdDev) const;
+    double get_estimate() const;
+    double get_composite_estimate() const;
+    double get_lower_bound(int num_std_dev) const;
+    double get_upper_bound(int num_std_dev) const;
 
-    int getCompactSerializationBytes() const;
-    int getUpdatableSerializationBytes() const;
-    int getLgConfigK() const;
+    int get_compact_serialization_bytes() const;
+    int get_updatable_serialization_bytes() const;
+    int get_lg_config_k() const;
 
-    TgtHllType getTgtHllType() const;
-    bool isCompact() const;
-    bool isEmpty() const;
+    target_hll_type get_target_type() const;
+    bool is_compact() const;
+    bool is_empty() const;
 
     void reset();
 
-    HllSketch<A> getResult(TgtHllType tgtHllType = HLL_4) const;
+    hll_sketch_alloc<A> get_result(target_hll_type tgt_type = HLL_4) const;
 
-    std::pair<byte_ptr_with_deleter, const size_t> serializeCompact() const;
-    std::pair<byte_ptr_with_deleter, const size_t> serializeUpdatable() const;
-    void serializeCompact(std::ostream& os) const;
-    void serializeUpdatable(std::ostream& os) const;
+    std::pair<byte_ptr_with_deleter, const size_t> serialize_compact() const;
+    std::pair<byte_ptr_with_deleter, const size_t> serialize_updatable() const;
+    void serialize_compact(std::ostream& os) const;
+    void serialize_updatable(std::ostream& os) const;
 
     std::ostream& to_string(std::ostream& os,
                             bool summary = true,
                             bool detail = false,
-                            bool auxDetail = false,
+                            bool aux_Detail = false,
                             bool all = false) const;
     std::string to_string(bool summary = true,
                           bool detail = false,
-                          bool auxDetail = false,
+                          bool aux_detail = false,
                           bool all = false) const;                                    
 
-    void update(const HllSketch<A>& sketch);
+    void update(const hll_sketch_alloc<A>& sketch);
     void update(const std::string& datum);
     void update(uint64_t datum);
     void update(uint32_t datum);
@@ -191,11 +190,11 @@ class HllUnion {
     void update(int8_t datum);
     void update(double datum);
     void update(float datum);
-    void update(const void* data, size_t lengthBytes);
+    void update(const void* data, size_t length_bytes);
 
-    static int getMaxSerializationBytes(int lgK);
-    static double getRelErr(bool upperBound, bool unioned,
-                            int lgConfigK, int numStdDev);
+    static int get_max_serialization_bytes(int lg_k);
+    static double get_rel_err(bool upper_bound, bool unioned,
+                              int lg_config_k, int num_std_dev);
 
   private:
 
@@ -227,19 +226,19 @@ class HllUnion {
     static HllSketchImpl<A>* leakFreeCouponUpdate(HllSketchImpl<A>* impl, int coupon);
 
     int lgMaxK;
-    HllSketch<A> gadget;
+    hll_sketch_alloc<A> gadget;
 
 };
 
 template<typename A>
-static std::ostream& operator<<(std::ostream& os, const HllSketch<A>& sketch);
+static std::ostream& operator<<(std::ostream& os, const hll_sketch_alloc<A>& sketch);
 
 template<typename A>
-static std::ostream& operator<<(std::ostream& os, const HllUnion<A>& hllUnion);
+static std::ostream& operator<<(std::ostream& os, const hll_union_alloc<A>& union_in);
 
 // aliases with default allocator for convenience
-typedef HllSketch<> hll_sketch;
-typedef HllUnion<> hll_union;
+typedef hll_sketch_alloc<> hll_sketch;
+typedef hll_union_alloc<> hll_union;
 
 } // namespace datasketches
 

--- a/hll/test/CouponHashSetTest.cpp
+++ b/hll/test/CouponHashSetTest.cpp
@@ -43,7 +43,7 @@ class CouponHashSetTest : public CppUnit::TestFixture {
     for (int i = 0; i < 24; ++i) {
       sk1.update(i);
     }
-    std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> sketchBytes = sk1.serializeUpdatable();
+    std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> sketchBytes = sk1.serialize_updatable();
     uint8_t* bytes = sketchBytes.first.get();
 
     bytes[HllUtil<>::PREAMBLE_INTS_BYTE] = 0;
@@ -103,7 +103,7 @@ class CouponHashSetTest : public CppUnit::TestFixture {
       sk1.update(i);
     }
     std::stringstream ss;
-    sk1.serializeCompact(ss);
+    sk1.serialize_compact(ss);
 
     ss.seekp(HllUtil<>::PREAMBLE_INTS_BYTE);
     ss.put(0);

--- a/hll/test/CouponListTest.cpp
+++ b/hll/test/CouponListTest.cpp
@@ -48,7 +48,7 @@ class CouponListTest : public CppUnit::TestFixture {
     int lgConfigK = 8;
     CouponList<>* sk = new CouponList<>(lgConfigK, HLL_4, LIST);
     for (int i = 0; i < 7; ++i) { sk->couponUpdate(i); } // not hashes but distinct values
-    PairIterator_with_deleter<> itr = sk->getIterator();
+    pair_iterator_with_deleter<> itr = sk->getIterator();
     println_string(itr->getHeader());
     while (itr->nextAll()) {
       int key = itr->getKey();
@@ -71,22 +71,19 @@ class CouponListTest : public CppUnit::TestFixture {
       sk.update(i);
       sk.update(i);
     }
-    //CPPUNIT_ASSERT_EQUAL(sk.getCurrentMode(), CurMode::LIST);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getCompositeEstimate(), 7.0, 7 * 0.1);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_composite_estimate(), 7.0, 7 * 0.1);
 
     sk.update(8);
     sk.update(8);
-    //CPPUNIT_ASSERT_EQUAL(sk.getCurrentMode(), CurMode::SET);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getCompositeEstimate(), 8.0, 8 * 0.1);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_composite_estimate(), 8.0, 8 * 0.1);
 
     for (int i = 9; i <= 25; ++i) {
       sk.update(i);
       sk.update(i);
     }
-    //CPPUNIT_ASSERT_EQUAL(sk.getCurrentMode(), CurMode::HLL);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getCompositeEstimate(), 25.0, 25 * 0.1);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_composite_estimate(), 25.0, 25 * 0.1);
 
-    double relErr = sk.getRelErr(true, true, 4, 1);
+    double relErr = sk.get_rel_err(true, true, 4, 1);
     CPPUNIT_ASSERT(relErr < 0.0);
   }
 
@@ -109,21 +106,21 @@ class CouponListTest : public CppUnit::TestFixture {
     for (int i = 0; i < u; ++i) {
       sk1.update(i);
     }
-    double est1 = sk1.getEstimate();
+    double est1 = sk1.get_estimate();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(est1, u, u * 1e-4);
 
     std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
-    sk1.serializeCompact(ss);
+    sk1.serialize_compact(ss);
     hll_sketch sk2 = hll_sketch::deserialize(ss);
-    double est2 = sk2.getEstimate();
+    double est2 = sk2.get_estimate();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(est2, est1, 0.0);
 
     ss.str(std::string());
     ss.clear();
 
-    sk1.serializeUpdatable(ss);
+    sk1.serialize_updatable(ss);
     sk2 = hll_sketch::deserialize(ss);
-    est2 = sk2.getEstimate();
+    est2 = sk2.get_estimate();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(est2, est1, 0.0);
   }
   
@@ -137,7 +134,7 @@ class CouponListTest : public CppUnit::TestFixture {
     hll_sketch sk1(lgK);
     sk1.update(1);
     sk1.update(2);
-    std::pair<byte_ptr_with_deleter, const size_t> sketchBytes = sk1.serializeCompact();
+    std::pair<byte_ptr_with_deleter, const size_t> sketchBytes = sk1.serialize_compact();
     uint8_t* bytes = sketchBytes.first.get();
 
     bytes[HllUtil<>::PREAMBLE_INTS_BYTE] = 0;
@@ -184,7 +181,7 @@ class CouponListTest : public CppUnit::TestFixture {
     sk1.update(1);
     sk1.update(2);
     std::stringstream ss;
-    sk1.serializeCompact(ss);
+    sk1.serialize_compact(ss);
 
     ss.seekp(HllUtil<>::PREAMBLE_INTS_BYTE);
     ss.put(0);

--- a/hll/test/CrossCountingTest.cpp
+++ b/hll/test/CrossCountingTest.cpp
@@ -18,9 +18,6 @@
  */
 
 #include "hll.hpp"
-//#include "HllSketch.hpp"
-//#include "HllUnion.hpp"
-//#include "HllUtil.hpp"
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -36,7 +33,7 @@ class CrossCountingTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(crossCountingChecks);
   CPPUNIT_TEST_SUITE_END();
 
-  hll_sketch buildSketch(const int n, const int lgK, const TgtHllType tgtHllType) {
+  hll_sketch buildSketch(const int n, const int lgK, const target_hll_type tgtHllType) {
     hll_sketch sketch(lgK, tgtHllType);
     for (int i = 0; i < n; ++i) {
       sketch.update(i);
@@ -45,7 +42,7 @@ class CrossCountingTest : public CppUnit::TestFixture {
   }
 
   int computeChecksum(const hll_sketch& sketch) {
-    PairIterator_with_deleter<> itr = sketch.getIterator();
+    pair_iterator_with_deleter<> itr = sketch.get_iterator();
     int checksum = 0;
     int key;
     while(itr->nextAll()) {

--- a/hll/test/HllArrayTest.cpp
+++ b/hll/test/HllArrayTest.cpp
@@ -38,7 +38,7 @@ class HllArrayTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(checkCorruptStream);
   CPPUNIT_TEST_SUITE_END();
 
-  void testComposite(const int lgK, const TgtHllType tgtHllType, const int n) {
+  void testComposite(const int lgK, const target_hll_type tgtHllType, const int n) {
     hll_union u(lgK);
     hll_sketch sk(lgK, tgtHllType);
     for (int i = 0; i < n; ++i) {
@@ -46,16 +46,16 @@ class HllArrayTest : public CppUnit::TestFixture {
       sk.update(i);
     }
     u.update(sk); // merge
-    hll_sketch res = u.getResult(TgtHllType::HLL_8);
-    double est = res.getCompositeEstimate();
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(est, sk.getCompositeEstimate(), 0.0);
+    hll_sketch res = u.get_result(target_hll_type::HLL_8);
+    double est = res.get_composite_estimate();
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(est, sk.get_composite_estimate(), 0.0);
   }
 
   void checkCompositeEstimate() {
-    testComposite(4, TgtHllType::HLL_8, 10000);
-    testComposite(5, TgtHllType::HLL_8, 10000);
-    testComposite(6, TgtHllType::HLL_8, 10000);
-    testComposite(13, TgtHllType::HLL_8, 10000);
+    testComposite(4, target_hll_type::HLL_8, 10000);
+    testComposite(5, target_hll_type::HLL_8, 10000);
+    testComposite(6, target_hll_type::HLL_8, 10000);
+    testComposite(13, target_hll_type::HLL_8, 10000);
   }
 
   void checkSerializeDeserialize() {
@@ -78,7 +78,7 @@ class HllArrayTest : public CppUnit::TestFixture {
     serializeDeserialize(lgK, HLL_8, n);
   }
 
-  void serializeDeserialize(const int lgK, TgtHllType tgtHllType, const int n) {
+  void serializeDeserialize(const int lgK, target_hll_type tgtHllType, const int n) {
     hll_sketch sk1(lgK, tgtHllType);
 
     for (int i = 0; i < n; ++i) {
@@ -86,22 +86,22 @@ class HllArrayTest : public CppUnit::TestFixture {
     }
     //CPPUNIT_ASSERT(sk1.getCurrentMode() == CurMode::HLL);
 
-    double est1 = sk1.getEstimate();
+    double est1 = sk1.get_estimate();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(n, est1, n * 0.03);
 
     // serialize as compact and updatable, deserialize, compare estimates are exact
     std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
-    sk1.serializeCompact(ss);
+    sk1.serialize_compact(ss);
     hll_sketch sk2 = hll_sketch::deserialize(ss);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk2.getEstimate(), sk1.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk2.get_estimate(), sk1.get_estimate(), 0.0);
 
     ss.clear();
-    sk1.serializeUpdatable(ss);
+    sk1.serialize_updatable(ss);
     sk2 = hll_sketch::deserialize(ss);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk2.getEstimate(), sk1.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk2.get_estimate(), sk1.get_estimate(), 0.0);
 
     sk1.reset();
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, sk1.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, sk1.get_estimate(), 0.0);
   }
 
   void checkIsCompact() {
@@ -109,7 +109,7 @@ class HllArrayTest : public CppUnit::TestFixture {
     for (int i = 0; i < 8; ++i) {
       sk.update(i);
     }
-    CPPUNIT_ASSERT(!sk.isCompact());
+    CPPUNIT_ASSERT(!sk.is_compact());
   }
 
   void checkCorruptBytearray() {
@@ -118,7 +118,7 @@ class HllArrayTest : public CppUnit::TestFixture {
     for (int i = 0; i < 50; ++i) {
       sk1.update(i);
     }
-    std::pair<byte_ptr_with_deleter, size_t> sketchBytes = sk1.serializeCompact();
+    std::pair<byte_ptr_with_deleter, size_t> sketchBytes = sk1.serialize_compact();
     uint8_t* bytes = sketchBytes.first.get();
 
     bytes[HllUtil<>::PREAMBLE_INTS_BYTE] = 0;
@@ -170,7 +170,7 @@ class HllArrayTest : public CppUnit::TestFixture {
       sk1.update(i);
     }
     std::stringstream ss;
-    sk1.serializeCompact(ss);
+    sk1.serialize_compact(ss);
 
     ss.seekp(HllUtil<>::PREAMBLE_INTS_BYTE);
     ss.put(0);

--- a/hll/test/HllSketchTest.cpp
+++ b/hll/test/HllSketchTest.cpp
@@ -33,7 +33,6 @@ class hllSketchTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(checkNumStdDev);
   CPPUNIT_TEST(checkSerSizes);
   CPPUNIT_TEST(exerciseToString);
-  //CPPUNIT_TEST(checkEmptyCoupon);
   CPPUNIT_TEST(checkCompactFlag);
   CPPUNIT_TEST(checkKLimits);
   CPPUNIT_TEST(checkInputTypes);
@@ -45,43 +44,35 @@ class hllSketchTest : public CppUnit::TestFixture {
     runCheckCopy(8, HLL_8);
   }
 
-  void runCheckCopy(int lgConfigK, TgtHllType tgtHllType) {
+  void runCheckCopy(int lgConfigK, target_hll_type tgtHllType) {
     hll_sketch sk(lgConfigK, tgtHllType);
 
     for (int i = 0; i < 7; ++i) {
       sk.update(i);
     }
-    //CPPUNIT_ASSERT_EQUAL(sk.getCurrentMode(), CurMode::LIST);
 
     hll_sketch skCopy = sk;
-    //CPPUNIT_ASSERT_EQUAL(skCopyPvt.getCurrentMode(), CurMode::LIST);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(skCopy.getEstimate(), sk.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(skCopy.get_estimate(), sk.get_estimate(), 0.0);
 
     // no access to hllSketchImpl, so we'll ensure those differ by adding more
     // data to sk and ensuring the mode and estimates differ
     for (int i = 7; i < 24; ++i) {
       sk.update(i);
     }
-    //CPPUNIT_ASSERT_EQUAL(sk.getCurrentMode(), CurMode::SET);
-    //CPPUNIT_ASSERT(sk.getCurrentMode() != skCopyPvt.getCurrentMode());
-    CPPUNIT_ASSERT(16.0 < (sk.getEstimate() - skCopy.getEstimate()));
+    CPPUNIT_ASSERT(16.0 < (sk.get_estimate() - skCopy.get_estimate()));
 
     skCopy = sk;
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(skCopy.getEstimate(), sk.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(skCopy.get_estimate(), sk.get_estimate(), 0.0);
 
-    int u = (sk.getTgtHllType() == HLL_4) ? 100000 : 25;
+    int u = (sk.get_target_type() == HLL_4) ? 100000 : 25;
     for (int i = 24; i < u; ++i) {
       sk.update(i);
     }
-    //CPPUNIT_ASSERT_EQUAL(sk.getCurrentMode(), CurMode::HLL);
-    //CPPUNIT_ASSERT(sk.getCurrentMode() != skCopyPvt.getCurrentMode());
-    CPPUNIT_ASSERT(sk.getEstimate() != skCopy.getEstimate()); // either 1 or 100k difference
+    CPPUNIT_ASSERT(sk.get_estimate() != skCopy.get_estimate()); // either 1 or 100k difference
 
     skCopy = sk;
-    //CPPUNIT_ASSERT_EQUAL(skCopyPvt.getCurrentMode(), CurMode::HLL);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(skCopy.getEstimate(), sk.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(skCopy.get_estimate(), sk.get_estimate(), 0.0);
 
-    //CPPUNIT_ASSERT(sk.hllSketchImpl != skCopyPvt.hllSketchImpl);
   }
 
   void checkCopyAs() {
@@ -96,7 +87,7 @@ class hllSketchTest : public CppUnit::TestFixture {
     copyAs(HLL_8, HLL_8);
   }
 
-  void copyAs(TgtHllType srcType, TgtHllType dstType) {
+  void copyAs(target_hll_type srcType, target_hll_type dstType) {
     int lgK = 8;
     int n1 = 7;
     int n2 = 24;
@@ -108,53 +99,40 @@ class hllSketchTest : public CppUnit::TestFixture {
       src.update(i + base);
     }
     hll_sketch dst(src, dstType);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(dst.getEstimate(), src.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(dst.get_estimate(), src.get_estimate(), 0.0);
 
     for (int i = n1; i < n2; ++i) {
       src.update(i + base);
     }
     dst = hll_sketch(src, dstType);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(dst.getEstimate(), src.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(dst.get_estimate(), src.get_estimate(), 0.0);
 
     for (int i = n2; i < n3; ++i) {
       src.update(i + base);
     }
     dst = hll_sketch(src, dstType);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(dst.getEstimate(), src.getEstimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(dst.get_estimate(), src.get_estimate(), 0.0);
   }
 
   void checkMisc1() {
     int lgConfigK = 8;
-    TgtHllType srcType = TgtHllType::HLL_8;
+    target_hll_type srcType = target_hll_type::HLL_8;
     hll_sketch sk(lgConfigK, srcType);
 
     for (int i = 0; i < 7; ++i) { sk.update(i); } // LIST
-    //CouponList* cl = (CouponList*) s.hllSketchImpl;
-    //CPPUNIT_ASSERT_EQUAL(7, cl.getCouponCount());
-    //HllSketchImpl* impl = s.hllSketchImpl;
-    CPPUNIT_ASSERT_EQUAL(36, sk.getCompactSerializationBytes());
-    CPPUNIT_ASSERT_EQUAL(40, sk.getUpdatableSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(36, sk.get_compact_serialization_bytes());
+    CPPUNIT_ASSERT_EQUAL(40, sk.get_updatable_serialization_bytes());
 
     for (int i = 7; i < 24; ++i) { sk.update(i); } // SET
-    //CouponHashSet* chs = (CouponHashSet*) s.hllSketchImpl;
-    //CPPUNIT_ASSERT_EQUAL(24, chs.getCouponCount());
-    //impl = s.hllSketchImpl;
-    CPPUNIT_ASSERT_EQUAL(108, sk.getCompactSerializationBytes());
-    CPPUNIT_ASSERT_EQUAL(140, sk.getUpdatableSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(108, sk.get_compact_serialization_bytes());
+    CPPUNIT_ASSERT_EQUAL(140, sk.get_updatable_serialization_bytes());
 
     sk.update(24); // HLL
-    //HllArray* arr = (HllArray*) s.hllSketchImpl;
-    //CPPUNIT_ASSERT(arr.getAuxIterator() == nullptr);
-    //CPPUNIT_ASSERT_EQUAL(0, arr.getCurMin());
-    //CPPUNIT_ASSERT_DOUBLES_EQUAL(25.0, arr.getHipAccum(), 25.0 * 0.02);
-    //CPPUNIT_ASSERT(arr.getNumAtCurMin() >= 0);
-    //CPPUNIT_ASSERT_EQUAL(40 + 256, arr.getUpdatableSerializationBytes());
-    //CPPUNIT_ASSERT_EQUAL(10, arr.getPreInts());
-    CPPUNIT_ASSERT_EQUAL(40 + 256, sk.getUpdatableSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(40 + 256, sk.get_updatable_serialization_bytes());
 
     const int hllBytes = HllUtil<>::HLL_BYTE_ARR_START + (1 << lgConfigK);
-    CPPUNIT_ASSERT_EQUAL(hllBytes, sk.getCompactSerializationBytes());
-    CPPUNIT_ASSERT_EQUAL(hllBytes, hll_sketch::getMaxUpdatableSerializationBytes(lgConfigK, HLL_8));
+    CPPUNIT_ASSERT_EQUAL(hllBytes, sk.get_compact_serialization_bytes());
+    CPPUNIT_ASSERT_EQUAL(hllBytes, hll_sketch::get_max_updatable_serialization_bytes(lgConfigK, HLL_8));
   }
 
   void checkNumStdDev() {
@@ -168,23 +146,23 @@ class hllSketchTest : public CppUnit::TestFixture {
     checkSerializationSizes(8, HLL_4);
   }
 
-  void checkSerializationSizes(const int lgConfigK, TgtHllType tgtHllType) {
+  void checkSerializationSizes(const int lgConfigK, target_hll_type tgtHllType) {
     hll_sketch sk(lgConfigK, tgtHllType);
     int i;
 
     // LIST
     for (i = 0; i < 7; ++i) { sk.update(i); }
     int expected = HllUtil<>::LIST_INT_ARR_START + (i << 2);
-    CPPUNIT_ASSERT_EQUAL(expected, sk.getCompactSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(expected, sk.get_compact_serialization_bytes());
     expected = HllUtil<>::LIST_INT_ARR_START + (4 << HllUtil<>::LG_INIT_LIST_SIZE);
-    CPPUNIT_ASSERT_EQUAL(expected, sk.getUpdatableSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(expected, sk.get_updatable_serialization_bytes());
 
     // SET
     for (i = 7; i < 24; ++i) { sk.update(i); }
     expected = HllUtil<>::HASH_SET_INT_ARR_START + (i << 2);
-    CPPUNIT_ASSERT_EQUAL(expected, sk.getCompactSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(expected, sk.get_compact_serialization_bytes());
     expected = HllUtil<>::HASH_SET_INT_ARR_START + (4 << HllUtil<>::LG_INIT_SET_SIZE);
-    CPPUNIT_ASSERT_EQUAL(expected, sk.getUpdatableSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(expected, sk.get_updatable_serialization_bytes());
 
     // HLL
     sk.update(i);
@@ -194,7 +172,7 @@ class hllSketchTest : public CppUnit::TestFixture {
   /*
     int auxCountBytes = 0;
     int auxArrBytes = 0;
-    if (hllArr.getTgtHllType() == TgtHllType::HLL_4) {
+    if (hllArr.getTgtHllType() == target_hll_type::HLL_4) {
       AuxHashMap* auxMap = hllArr.getAuxHashMap();
       if (auxMap != nullptr) {
         auxCountBytes = auxMap.getAuxCount() << 2;
@@ -205,14 +183,14 @@ class hllSketchTest : public CppUnit::TestFixture {
     }
     int hllArrBytes = hllArr.getHllByteArrBytes();
     expected = HllUtil<>::HLL_BYTE_ARR_START + hllArrBytes + auxCountBytes;
-    CPPUNIT_ASSERT_EQUAL(expected, sk.getCompactSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(expected, sk.get_compact_serialization_bytes());
     expected = HllUtil<>::HLL_BYTE_ARR_START + hllArrBytes + auxArrBytes;
-    CPPUNIT_ASSERT_EQUAL(expected, sk.getUpdatableSerializationBytes());
+    CPPUNIT_ASSERT_EQUAL(expected, sk.get_updatable_serialization_bytes());
     
     int fullAuxArrBytes = (tgtHllType == HLL_4) ? (4 << HllUtil<>::LG_AUX_ARR_INTS[lgConfigK]) : 0;
     expected = HllUtil<>::HLL_BYTE_ARR_START + hllArrBytes + fullAuxArrBytes;
     CPPUNIT_ASSERT_EQUAL(expected,
-                         HllSketch::getMaxUpdatableSerializationBytes(lgConfigK, tgtHllType));
+                         HllSketch::get_max_updatable_serialization_bytes(lgConfigK, tgtHllType));
   */
   }
 
@@ -231,30 +209,16 @@ class hllSketchTest : public CppUnit::TestFixture {
     sk.to_string(oss, false, true, true, true);
   }
   
-  /*
-  // removed: no access to HllSketchImpl so can't perform this test
-  void checkEmptyCoupon() {
-    int lgK = 8;
-    TgtHllType type = HLL_8;
-    hll_sketch sk = hll_sketch(lgK, type);
-    for (int i = 0; i < 20; ++i) { sk.update(i); } // SET mode
-    static_cast<HllSketchPvt*>(sk.get()).couponUpdate(0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(20, sk.getEstimate(), 0.001);
-  }
-  */
-
   void checkCompactFlag() {
     int lgK = 8;
     // unless/until we create non-updatable "direct" versions,
     // deserialized image should never be compact
     // LIST: follows serialization request
     CPPUNIT_ASSERT(checkCompact(lgK, 7, HLL_8, false) == false);
-    //CPPUNIT_ASSERT(checkCompact(lgK, 7, HLL_8, true) == true);
     CPPUNIT_ASSERT(checkCompact(lgK, 7, HLL_8, true) == false);
 
     // SET: follows serialization request
     CPPUNIT_ASSERT(checkCompact(lgK, 24, HLL_8, false) == false);
-    //CPPUNIT_ASSERT(checkCompact(lgK, 24, HLL_8, true) == true);
     CPPUNIT_ASSERT(checkCompact(lgK, 24, HLL_8, true) == false);
 
     // HLL8: always updatable
@@ -267,35 +231,34 @@ class hllSketchTest : public CppUnit::TestFixture {
 
     // HLL4: follows serialization request
     CPPUNIT_ASSERT(checkCompact(lgK, 25, HLL_4, false) == false);
-    //CPPUNIT_ASSERT(checkCompact(lgK, 25, HLL_4, true) == true);
     CPPUNIT_ASSERT(checkCompact(lgK, 25, HLL_4, true) == false);
   }
 
   // Creates and serializes then deserializes sketch.
   // Returns true if deserialized sketch is compact.
-  bool checkCompact(const int lgK, const int n, const TgtHllType type, bool compact) {
+  bool checkCompact(const int lgK, const int n, const target_hll_type type, bool compact) {
     hll_sketch sk(lgK, type);
     for (int i = 0; i < n; ++i) { sk.update(i); }
     
     std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
     if (compact) { 
-      sk.serializeCompact(ss);
-      CPPUNIT_ASSERT_EQUAL(sk.getCompactSerializationBytes(), (int) ss.tellp());
+      sk.serialize_compact(ss);
+      CPPUNIT_ASSERT_EQUAL(sk.get_compact_serialization_bytes(), (int) ss.tellp());
     } else {
-      sk.serializeUpdatable(ss);
-      CPPUNIT_ASSERT_EQUAL(sk.getUpdatableSerializationBytes(), (int) ss.tellp());
+      sk.serialize_updatable(ss);
+      CPPUNIT_ASSERT_EQUAL(sk.get_updatable_serialization_bytes(), (int) ss.tellp());
     }
     
     hll_sketch sk2 = hll_sketch::deserialize(ss);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(n, sk2.getEstimate(), 0.01);
-    bool isCompact = sk2.isCompact();
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(n, sk2.get_estimate(), 0.01);
+    bool isCompact = sk2.is_compact();
 
     return isCompact;
   }
 
   void checkKLimits() {
-    hll_sketch sketch1(HllUtil<>::MIN_LOG_K, TgtHllType::HLL_8);
-    hll_sketch sketch2(HllUtil<>::MAX_LOG_K, TgtHllType::HLL_4);
+    hll_sketch sketch1(HllUtil<>::MIN_LOG_K, target_hll_type::HLL_8);
+    hll_sketch sketch2(HllUtil<>::MAX_LOG_K, target_hll_type::HLL_4);
     CPPUNIT_ASSERT_THROW_MESSAGE("Failed to throw with lgK too small",
                                  hll_sketch(HllUtil<>::MIN_LOG_K - 1),
                                  std::invalid_argument);
@@ -306,7 +269,7 @@ class hllSketchTest : public CppUnit::TestFixture {
   }
 
     void checkInputTypes() {
-    hll_sketch sk(8, TgtHllType::HLL_8);
+    hll_sketch sk(8, target_hll_type::HLL_8);
 
     // inserting the same value as a variety of input types
     sk.update((uint8_t) 102);
@@ -317,7 +280,7 @@ class hllSketchTest : public CppUnit::TestFixture {
     sk.update((int16_t) 102);
     sk.update((int32_t) 102);
     sk.update((int64_t) 102);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, sk.getEstimate(), 0.01);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, sk.get_estimate(), 0.01);
 
     // identical binary representations
     // no unsigned in Java, but need to sign-extend both as Java would do 
@@ -330,24 +293,24 @@ class hllSketchTest : public CppUnit::TestFixture {
     std::string str = "input string";
     sk.update(str);
     sk.update(str.c_str(), str.length());
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(4.0, sk.getEstimate(), 0.01);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(4.0, sk.get_estimate(), 0.01);
 
-    sk = hll_sketch(8, TgtHllType::HLL_6);
+    sk = hll_sketch(8, target_hll_type::HLL_6);
     sk.update((float) 0.0);
     sk.update((float) -0.0);
     sk.update((double) 0.0);
     sk.update((double) -0.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, sk.getEstimate(), 0.01);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, sk.get_estimate(), 0.01);
 
-    sk = hll_sketch(8, TgtHllType::HLL_4);
+    sk = hll_sketch(8, target_hll_type::HLL_4);
     sk.update(std::nanf("3"));
     sk.update(std::nan("9"));
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, sk.getEstimate(), 0.01);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, sk.get_estimate(), 0.01);
 
-    sk = hll_sketch(8, TgtHllType::HLL_4);
+    sk = hll_sketch(8, target_hll_type::HLL_4);
     sk.update(nullptr, 0);
     sk.update("");
-    CPPUNIT_ASSERT(sk.isEmpty());
+    CPPUNIT_ASSERT(sk.is_empty());
   }
 
 };

--- a/hll/test/ToFromByteArrayTest.cpp
+++ b/hll/test/ToFromByteArrayTest.cpp
@@ -18,9 +18,6 @@
  */
 
 #include "hll.hpp"
-//#include "CouponList.hpp"
-//#include "CouponHashSet.hpp"
-//#include "HllArray.hpp"
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -45,25 +42,16 @@ class ToFromByteArrayTest : public CppUnit::TestFixture {
     }
     
     std::stringstream ss1;
-    sk.serializeUpdatable(ss1);
-    std::pair<byte_ptr_with_deleter, size_t> ser1 = sk.serializeUpdatable();
+    sk.serialize_updatable(ss1);
+    std::pair<byte_ptr_with_deleter, size_t> ser1 = sk.serialize_updatable();
 
     std::stringstream ss;
-    sk.serializeUpdatable(ss);
+    sk.serialize_updatable(ss);
     std::string str = ss.str();
 
 
     hll_sketch sk2 = hll_sketch::deserialize(ser1.first.get(), ser1.second);
-    //hll_sketch sk2 = HllSketch::deserialize(ss1);
-    
-    //std::stringstream ss2;
-    //sk2->serializeUpdatable(ss2);
-    std::pair<byte_ptr_with_deleter, size_t> ser2 = sk.serializeUpdatable();
-
-    // std::string b1 = ss1.str();
-    // std::string b2 = ss2.str();
-    // CPPUNIT_ASSERT_EQUAL(b1.length(), b2.length());
-    // int len = b1.length();
+    std::pair<byte_ptr_with_deleter, size_t> ser2 = sk.serialize_updatable();
 
     CPPUNIT_ASSERT_EQUAL(ser1.second, ser2.second);
     int len = ser1.second;
@@ -71,21 +59,7 @@ class ToFromByteArrayTest : public CppUnit::TestFixture {
     uint8_t* b2 = ser2.first.get();
 
     for (int i = 0; i < len; ++i) {
-      if (b1[i] != b2[i]) {
-        hll_sketch from_ss = hll_sketch::deserialize(ss1);
-        std::cout << "ser3:\n";
-        std::pair<byte_ptr_with_deleter, size_t> ser3 = from_ss.serializeUpdatable();
-        uint8_t* b3 = ser3.first.get();
-        
-        std::cerr << "Mismatch at byte " << i << "\n";
-        std::cerr << "b1: " << b1[i] << "\n";
-        std::cerr << "b2: " << b2[i] << "\n";
-        std::cerr << "b3: " << b3[i] << "\n";
-        //std::cerr << sk->to_string(true, true, true, true) << "\n";
-        //std::cerr << sk2->to_string(true, true, true, true) << "\n";
-        //std::cerr << from_ss->to_string(true, true, true, true) << "\n";
-        CPPUNIT_ASSERT_EQUAL(b1[i], b2[i]);
-      }
+      CPPUNIT_ASSERT_EQUAL(b1[i], b2[i]);
     }
   }
 
@@ -100,170 +74,94 @@ class ToFromByteArrayTest : public CppUnit::TestFixture {
     std::ifstream ifs;
     ifs.open(inputPath + "list_from_java.bin", std::ios::binary);
     hll_sketch sk = hll_sketch::deserialize(ifs);
-    CPPUNIT_ASSERT(sk.isEmpty() == false);
-    CPPUNIT_ASSERT_EQUAL(sk.getLgConfigK(), 8);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getLowerBound(1), 7.0, 0.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getEstimate(), 7.0, 1e-6); // java: 7.000000104308129
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getUpperBound(1), 7.000350, 1e-5); // java: 7.000349609067664
-
-    /*
-    HllSketchPvt* s = static_cast<HllSketchPvt*>(sk.get());
-    CPPUNIT_ASSERT(s->hllSketchImpl->getCurMode() == LIST);
-    CouponList* cl = (CouponList*) s->hllSketchImpl;
-    CPPUNIT_ASSERT_EQUAL(cl->getCouponCount(), 7);
-    */
+    CPPUNIT_ASSERT(sk.is_empty() == false);
+    CPPUNIT_ASSERT_EQUAL(sk.get_lg_config_k(), 8);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_lower_bound(1), 7.0, 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_estimate(), 7.0, 1e-6); // java: 7.000000104308129
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_upper_bound(1), 7.000350, 1e-5); // java: 7.000349609067664
     ifs.close();
 
     ifs.open(inputPath + "compact_set_from_java.bin", std::ios::binary);
     sk = hll_sketch::deserialize(ifs);
-    CPPUNIT_ASSERT(sk.isEmpty() == false);
-    CPPUNIT_ASSERT_EQUAL(sk.getLgConfigK(), 8);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getLowerBound(1), 24.0, 0.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getEstimate(), 24.0, 1e-5); // java: 24.00000137090692
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getUpperBound(1), 24.001200, 1e-5); // java: 24.0011996729902
-
-    /*
-    s = static_cast<HllSketchPvt*>(sk.get());
-    CPPUNIT_ASSERT(s->hllSketchImpl->getCurMode() == SET);
-    CouponHashSet* chs = (CouponHashSet*) s->hllSketchImpl;
-    CPPUNIT_ASSERT_EQUAL(chs->getCouponCount(), 24);
-    */
+    CPPUNIT_ASSERT(sk.is_empty() == false);
+    CPPUNIT_ASSERT_EQUAL(sk.get_lg_config_k(), 8);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_lower_bound(1), 24.0, 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_estimate(), 24.0, 1e-5); // java: 24.00000137090692
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_upper_bound(1), 24.001200, 1e-5); // java: 24.0011996729902
     ifs.close();
 
     ifs.open(inputPath + "updatable_set_from_java.bin", std::ios::binary);
     sk = hll_sketch::deserialize(ifs);
-    CPPUNIT_ASSERT(sk.isEmpty() == false);
-    CPPUNIT_ASSERT_EQUAL(sk.getLgConfigK(), 8);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getLowerBound(1), 24.0, 0.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getEstimate(), 24.0, 1e-5); // java: 24.00000137090692
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getUpperBound(1), 24.001200, 1e-5); // java: 24.0011996729902
-
-    /*
-    s = static_cast<HllSketchPvt*>(sk.get());
-    CPPUNIT_ASSERT(s->hllSketchImpl->getCurMode() == SET);
-    chs = (CouponHashSet*) s->hllSketchImpl;
-    CPPUNIT_ASSERT_EQUAL(chs->getCouponCount(), 24);
-    */
+    CPPUNIT_ASSERT(sk.is_empty() == false);
+    CPPUNIT_ASSERT_EQUAL(sk.get_lg_config_k(), 8);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_lower_bound(1), 24.0, 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_estimate(), 24.0, 1e-5); // java: 24.00000137090692
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_upper_bound(1), 24.001200, 1e-5); // java: 24.0011996729902
     ifs.close();
 
 
     ifs.open(inputPath + "array6_from_java.bin", std::ios::binary);
     sk = hll_sketch::deserialize(ifs);
-    CPPUNIT_ASSERT(sk.isEmpty() == false);
-    CPPUNIT_ASSERT_EQUAL(sk.getLgConfigK(), 8);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getLowerBound(1), 9589.968564, 1e-5); // java: 9589.968564432073
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getEstimate(), 10089.150211, 1e-5); // java: 10089.1502113328
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getUpperBound(1), 10642.370492, 1e-5); // java: 10642.370491998483
-
-    /*
-    s = static_cast<HllSketchPvt*>(sk.get());
-    CPPUNIT_ASSERT(sk->getTgtHllType() == HLL_6);
-    CPPUNIT_ASSERT(s->hllSketchImpl->getCurMode() == HLL);
-    HllArray* ha = (HllArray*) s->hllSketchImpl;
-    CPPUNIT_ASSERT_EQUAL(ha->getCurMin(), 0);
-    CPPUNIT_ASSERT_EQUAL(ha->getNumAtCurMin(), 0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(ha->getKxQ0(), 4.507751, 1e-6); // java: 4.50775146484375
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(ha->getKxQ1(), 0.0, 0.0);
-    */
+    CPPUNIT_ASSERT(sk.is_empty() == false);
+    CPPUNIT_ASSERT_EQUAL(sk.get_lg_config_k(), 8);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_lower_bound(1), 9589.968564, 1e-5); // java: 9589.968564432073
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_estimate(), 10089.150211, 1e-5); // java: 10089.1502113328
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_upper_bound(1), 10642.370492, 1e-5); // java: 10642.370491998483
     ifs.close();
 
 
     ifs.open(inputPath + "compact_array4_from_java.bin", std::ios::binary);
     sk = hll_sketch::deserialize(ifs);
-    CPPUNIT_ASSERT(sk.isEmpty() == false);
-    CPPUNIT_ASSERT_EQUAL(sk.getLgConfigK(), 8);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getLowerBound(1), 9589.968564, 1e-5); // java: 9589.968564432073
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getEstimate(), 10089.150211, 1e-5); // java: 10089.1502113328
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getUpperBound(1), 10642.370492, 1e-5); // java: 10642.370491998483
+    CPPUNIT_ASSERT(sk.is_empty() == false);
+    CPPUNIT_ASSERT_EQUAL(sk.get_lg_config_k(), 8);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_lower_bound(1), 9589.968564, 1e-5); // java: 9589.968564432073
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_estimate(), 10089.150211, 1e-5); // java: 10089.1502113328
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_upper_bound(1), 10642.370492, 1e-5); // java: 10642.370491998483
 
-    /*
-    s = static_cast<HllSketchPvt*>(sk.get());
-    CPPUNIT_ASSERT(sk->getTgtHllType() == HLL_4);
-    CPPUNIT_ASSERT(s->hllSketchImpl->getCurMode() == HLL);
-    ha = (HllArray*) s->hllSketchImpl;
-    CPPUNIT_ASSERT_EQUAL(ha->getCurMin(), 3);
-    CPPUNIT_ASSERT_EQUAL(ha->getNumAtCurMin(), 1);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(ha->getKxQ0(), 4.507751, 1e-6); // java: 4.50775146484375
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(ha->getKxQ1(), 0.0, 0.0);
-    */
     ifs.close();
 
 
     ifs.open(inputPath + "updatable_array4_from_java.bin", std::ios::binary);
     sk = hll_sketch::deserialize(ifs);
-    CPPUNIT_ASSERT(sk.isEmpty() == false);
-    CPPUNIT_ASSERT_EQUAL(sk.getLgConfigK(), 8);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getLowerBound(1), 9589.968564, 1e-5); // java: 9589.968564432073
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getEstimate(), 10089.150211, 1e-5); // java: 10089.1502113328
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.getUpperBound(1), 10642.370492, 1e-5); // java: 10642.370491998483
-
-    /*
-    s = static_cast<HllSketchPvt*>(sk.get());
-    CPPUNIT_ASSERT(sk->getTgtHllType() == HLL_4);
-    CPPUNIT_ASSERT(s->hllSketchImpl->getCurMode() == HLL);
-    ha = (HllArray*) s->hllSketchImpl;
-    CPPUNIT_ASSERT_EQUAL(ha->getCurMin(), 3);
-    CPPUNIT_ASSERT_EQUAL(ha->getNumAtCurMin(), 1);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(ha->getKxQ0(), 4.507751, 1e-6); // java: 4.50775146484375
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(ha->getKxQ1(), 0.0, 0.0);
-    */
+    CPPUNIT_ASSERT(sk.is_empty() == false);
+    CPPUNIT_ASSERT_EQUAL(sk.get_lg_config_k(), 8);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_lower_bound(1), 9589.968564, 1e-5); // java: 9589.968564432073
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_estimate(), 10089.150211, 1e-5); // java: 10089.1502113328
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk.get_upper_bound(1), 10642.370492, 1e-5); // java: 10642.370491998483
     ifs.close();
   }
 
-  void toFrom(const int lgConfigK, const TgtHllType tgtHllType, const int n) {
+  void toFrom(const int lgConfigK, const target_hll_type tgtHllType, const int n) {
     hll_sketch src(lgConfigK, tgtHllType);
     for (int i = 0; i < n; ++i) {
       src.update(i);
     }
 
     std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
-    src.serializeCompact(ss);
+    src.serialize_compact(ss);
     hll_sketch dst = hll_sketch::deserialize(ss);
     checkSketchEquality(src, dst);
 
-    std::pair<byte_ptr_with_deleter, const size_t> bytes1 = src.serializeCompact();
+    std::pair<byte_ptr_with_deleter, const size_t> bytes1 = src.serialize_compact();
     dst = hll_sketch::deserialize(bytes1.first.get(), bytes1.second);
     checkSketchEquality(src, dst);
 
     ss.clear();
-    src.serializeUpdatable(ss);
+    src.serialize_updatable(ss);
     dst = hll_sketch::deserialize(ss);
     checkSketchEquality(src, dst);
 
-    std::pair<byte_ptr_with_deleter, const size_t> bytes2 = src.serializeUpdatable();
+    std::pair<byte_ptr_with_deleter, const size_t> bytes2 = src.serialize_updatable();
     dst = hll_sketch::deserialize(bytes2.first.get(), bytes2.second);
     checkSketchEquality(src, dst);
   }
 
   void checkSketchEquality(hll_sketch& sk1, hll_sketch& sk2) {
-    //HllSketchPvt* sk1 = static_cast<HllSketchPvt*>(s1.get());
-    //HllSketchPvt* sk2 = static_cast<HllSketchPvt*>(s2.get());
-
-    CPPUNIT_ASSERT_EQUAL(sk1.getLgConfigK(), sk2.getLgConfigK());
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk1.getLowerBound(1), sk2.getLowerBound(1), 0.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk1.getEstimate(), sk2.getEstimate(), 0.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk1.getUpperBound(1), sk2.getUpperBound(1), 0.0);
-    //CPPUNIT_ASSERT_EQUAL(sk1->getCurrentMode(), sk2->getCurrentMode());
-    CPPUNIT_ASSERT_EQUAL(sk1.getTgtHllType(), sk2.getTgtHllType());
-
-    /*
-    if (sk1->getCurrentMode() == LIST) {
-      CouponList* cl1 = static_cast<CouponList*>(sk1->hllSketchImpl);
-      CouponList* cl2 = static_cast<CouponList*>(sk2->hllSketchImpl);
-      CPPUNIT_ASSERT_EQUAL(cl1->getCouponCount(), cl2->getCouponCount());
-    } else if (sk1->getCurrentMode() == SET) {
-      CouponHashSet* chs1 = static_cast<CouponHashSet*>(sk1->hllSketchImpl);
-      CouponHashSet* chs2 = static_cast<CouponHashSet*>(sk2->hllSketchImpl);
-      CPPUNIT_ASSERT_EQUAL(chs1->getCouponCount(), chs2->getCouponCount());
-    } else { // sk1->getCurrentMode() == HLL      
-      HllArray* ha1 = static_cast<HllArray*>(sk1->hllSketchImpl);
-      HllArray* ha2 = static_cast<HllArray*>(sk2->hllSketchImpl);
-      CPPUNIT_ASSERT_EQUAL(ha1->getCurMin(), ha2->getCurMin());
-      CPPUNIT_ASSERT_EQUAL(ha1->getNumAtCurMin(), ha2->getNumAtCurMin());
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(ha1->getKxQ0(), ha2->getKxQ0(), 0);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(ha1->getKxQ1(), ha2->getKxQ1(), 0);
-    }
-    */
+    CPPUNIT_ASSERT_EQUAL(sk1.get_lg_config_k(), sk2.get_lg_config_k());
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk1.get_lower_bound(1), sk2.get_lower_bound(1), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk1.get_estimate(), sk2.get_estimate(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(sk1.get_upper_bound(1), sk2.get_upper_bound(1), 0.0);
+    CPPUNIT_ASSERT_EQUAL(sk1.get_target_type(), sk2.get_target_type());
   }
 
   void toFromSketch() {

--- a/python/src/hll_wrapper.cpp
+++ b/python/src/hll_wrapper.cpp
@@ -26,33 +26,33 @@ namespace py = pybind11;
 namespace datasketches {
 namespace python {
 
-HllSketch<> hll_sketch_deserialize(py::bytes skBytes) {
+hll_sketch hll_sketch_deserialize(py::bytes skBytes) {
   std::string skStr = skBytes; // implicit cast  
-  return HllSketch<>::deserialize(skStr.c_str(), skStr.length());
+  return hll_sketch::deserialize(skStr.c_str(), skStr.length());
 }
 
-py::object hll_sketch_serialize_compact(const HllSketch<>& sk) {
-  auto serResult = sk.serializeCompact();
+py::object hll_sketch_serialize_compact(const hll_sketch& sk) {
+  auto serResult = sk.serialize_compact();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
 
-py::object hll_sketch_serialize_updatable(const HllSketch<>& sk) {
-  auto serResult = sk.serializeUpdatable();
+py::object hll_sketch_serialize_updatable(const hll_sketch& sk) {
+  auto serResult = sk.serialize_updatable();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
 
-HllUnion<> hll_union_deserialize(py::bytes uBytes) {
+hll_union hll_union_deserialize(py::bytes uBytes) {
   std::string uStr = uBytes; // implicit cast
-  return HllUnion<>::deserialize(uStr.c_str(), uStr.length());
+  return hll_union::deserialize(uStr.c_str(), uStr.length());
 }
 
-py::object hll_union_serialize_compact(const HllUnion<>& u) {
-  auto serResult = u.serializeCompact();
+py::object hll_union_serialize_compact(const hll_union& u) {
+  auto serResult = u.serialize_compact();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
 
-py::object hll_union_serialize_updatable(const HllUnion<>& u) {
-  auto serResult = u.serializeUpdatable();
+py::object hll_union_serialize_updatable(const hll_union& u) {
+  auto serResult = u.serialize_updatable();
   return py::bytes((char*)serResult.first.get(), serResult.second);
 }
 
@@ -64,70 +64,70 @@ namespace dspy = datasketches::python;
 void init_hll(py::module &m) {
   using namespace datasketches;
 
-  py::enum_<TgtHllType>(m, "tgt_hll_type", "Target HLL flavor")
+  py::enum_<target_hll_type>(m, "tgt_hll_type", "Target HLL flavor")
     .value("HLL_4", HLL_4)
     .value("HLL_6", HLL_6)
     .value("HLL_8", HLL_8)
     .export_values();
 
-  py::class_<HllSketch<>>(m, "hll_sketch")
+  py::class_<hll_sketch>(m, "hll_sketch")
     .def(py::init<int>(), py::arg("lg_k"))
-    .def(py::init<int, TgtHllType>(), py::arg("lg_k"), py::arg("tgt_hll_type"))
-    .def(py::init<int, TgtHllType, bool>(), py::arg("lg_k"), py::arg("tgt_hll_type"), py::arg("start_max_size")=false)
+    .def(py::init<int, target_hll_type>(), py::arg("lg_k"), py::arg("tgt_type"))
+    .def(py::init<int, target_hll_type, bool>(), py::arg("lg_k"), py::arg("tgt_type"), py::arg("start_max_size")=false)
     .def_static("deserialize", &dspy::hll_sketch_deserialize)
     .def("serialize_compact", &dspy::hll_sketch_serialize_compact)
     .def("serialize_updatable", &dspy::hll_sketch_serialize_updatable)
-    .def("to_string", (std::string (HllSketch<>::*)(bool,bool,bool,bool) const) &HllSketch<>::to_string,
+    .def("to_string", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
          py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
-    .def("__str__", (std::string (HllSketch<>::*)(bool,bool,bool,bool) const) &HllSketch<>::to_string,
+    .def("__str__", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
          py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
-    .def_property_readonly("lg_config_k", &HllSketch<>::getLgConfigK)
-    .def_property_readonly("tgt_hll_type", &HllSketch<>::getTgtHllType)
-    .def("get_estimate", &HllSketch<>::getEstimate)
-    .def("get_composite_estimate", &HllSketch<>::getCompositeEstimate)
-    .def("get_lower_bound", &HllSketch<>::getLowerBound, py::arg("num_std_devs"))
-    .def("get_upper_bound", &HllSketch<>::getUpperBound, py::arg("num_std_devs"))
-    .def("is_compact", &HllSketch<>::isCompact)
-    .def("is_empty", &HllSketch<>::isEmpty)
-    .def("get_updatable_serialization_bytes", &HllSketch<>::getUpdatableSerializationBytes)
-    .def("get_compact_serialization_bytes", &HllSketch<>::getCompactSerializationBytes)
-    .def("reset", &HllSketch<>::reset)
-    .def("update", (void (HllSketch<>::*)(int64_t)) &HllSketch<>::update, py::arg("datum"))
-    .def("update", (void (HllSketch<>::*)(double)) &HllSketch<>::update, py::arg("datum"))
-    .def("update", (void (HllSketch<>::*)(const std::string&)) &HllSketch<>::update, py::arg("datum"))
-    .def_static("get_max_updatable_serialization_bytes", &HllSketch<>::getMaxUpdatableSerializationBytes,
-         py::arg("lg_k"), py::arg("tgt_hll_type"))
-    .def_static("get_rel_err", &HllSketch<>::getRelErr,
+    .def_property_readonly("lg_config_k", &hll_sketch::get_lg_config_k)
+    .def_property_readonly("tgt_type", &hll_sketch::get_target_type)
+    .def("get_estimate", &hll_sketch::get_estimate)
+    .def("get_composite_estimate", &hll_sketch::get_composite_estimate)
+    .def("get_lower_bound", &hll_sketch::get_lower_bound, py::arg("num_std_devs"))
+    .def("get_upper_bound", &hll_sketch::get_upper_bound, py::arg("num_std_devs"))
+    .def("is_compact", &hll_sketch::is_compact)
+    .def("is_empty", &hll_sketch::is_empty)
+    .def("get_updatable_serialization_bytes", &hll_sketch::get_updatable_serialization_bytes)
+    .def("get_compact_serialization_bytes", &hll_sketch::get_compact_serialization_bytes)
+    .def("reset", &hll_sketch::reset)
+    .def("update", (void (hll_sketch::*)(int64_t)) &hll_sketch::update, py::arg("datum"))
+    .def("update", (void (hll_sketch::*)(double)) &hll_sketch::update, py::arg("datum"))
+    .def("update", (void (hll_sketch::*)(const std::string&)) &hll_sketch::update, py::arg("datum"))
+    .def_static("get_max_updatable_serialization_bytes", &hll_sketch::get_max_updatable_serialization_bytes,
+         py::arg("lg_k"), py::arg("tgt_type"))
+    .def_static("get_rel_err", &hll_sketch::get_rel_err,
          py::arg("upper_bound"), py::arg("unioned"), py::arg("lg_k"), py::arg("num_std_devs"))
     ;
 
-  py::class_<HllUnion<>>(m, "hll_union")
+  py::class_<hll_union>(m, "hll_union")
     .def(py::init<int>(), py::arg("lg_max_k"))
     .def_static("deserialize", &dspy::hll_union_deserialize)
     .def("serialize_compact", &dspy::hll_union_serialize_compact)
     .def("serialize_updatable", &dspy::hll_union_serialize_updatable)
-    .def("to_string", (std::string (HllUnion<>::*)(bool,bool,bool,bool) const) &HllUnion<>::to_string,
+    .def("to_string", (std::string (hll_union::*)(bool,bool,bool,bool) const) &hll_union::to_string,
          py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
-    .def("__str__", (std::string (HllUnion<>::*)(bool,bool,bool,bool) const) &HllUnion<>::to_string,
+    .def("__str__", (std::string (hll_union::*)(bool,bool,bool,bool) const) &hll_union::to_string,
          py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
-    .def_property_readonly("lg_config_k", &HllUnion<>::getLgConfigK)
-    .def_property_readonly("tgt_hll_type", &HllUnion<>::getTgtHllType)
-    .def("get_estimate", &HllUnion<>::getEstimate)
-    .def("get_composite_estimate", &HllUnion<>::getCompositeEstimate)
-    .def("get_lower_bound", &HllUnion<>::getLowerBound, py::arg("num_std_devs"))
-    .def("get_upper_bound", &HllUnion<>::getUpperBound, py::arg("num_std_devs"))
-    .def("is_compact", &HllUnion<>::isCompact)
-    .def("is_empty", &HllUnion<>::isEmpty)
-    .def("get_updatable_serialization_bytes", &HllUnion<>::getUpdatableSerializationBytes)
-    .def("get_compact_serialization_bytes", &HllUnion<>::getCompactSerializationBytes)
-    .def("reset", &HllUnion<>::reset)
-    .def("get_result", &HllUnion<>::getResult, py::arg("tgt_hll_type")=HLL_4)
-    .def<void (HllUnion<>::*)(const HllSketch<>&)>("update", &HllUnion<>::update, py::arg("sketch"))
-    .def<void (HllUnion<>::*)(int64_t)>("update", &HllUnion<>::update, py::arg("datum"))
-    .def<void (HllUnion<>::*)(double)>("update", &HllUnion<>::update, py::arg("datum"))
-    .def<void (HllUnion<>::*)(const std::string&)>("update", &HllUnion<>::update, py::arg("datum"))
-    .def_static("get_max_serialization_bytes", &HllUnion<>::getMaxSerializationBytes, py::arg("lg_k"))
-    .def_static("get_rel_err", &HllUnion<>::getRelErr,
+    .def_property_readonly("lg_config_k", &hll_union::get_lg_config_k)
+    .def_property_readonly("tgt_type", &hll_union::get_target_type)
+    .def("get_estimate", &hll_union::get_estimate)
+    .def("get_composite_estimate", &hll_union::get_composite_estimate)
+    .def("get_lower_bound", &hll_union::get_lower_bound, py::arg("num_std_devs"))
+    .def("get_upper_bound", &hll_union::get_upper_bound, py::arg("num_std_devs"))
+    .def("is_compact", &hll_union::is_compact)
+    .def("is_empty", &hll_union::is_empty)
+    .def("get_updatable_serialization_bytes", &hll_union::get_updatable_serialization_bytes)
+    .def("get_compact_serialization_bytes", &hll_union::get_compact_serialization_bytes)
+    .def("reset", &hll_union::reset)
+    .def("get_result", &hll_union::get_result, py::arg("tgt_type")=HLL_4)
+    .def<void (hll_union::*)(const hll_sketch&)>("update", &hll_union::update, py::arg("sketch"))
+    .def<void (hll_union::*)(int64_t)>("update", &hll_union::update, py::arg("datum"))
+    .def<void (hll_union::*)(double)>("update", &hll_union::update, py::arg("datum"))
+    .def<void (hll_union::*)(const std::string&)>("update", &hll_union::update, py::arg("datum"))
+    .def_static("get_max_serialization_bytes", &hll_union::get_max_serialization_bytes, py::arg("lg_k"))
+    .def_static("get_rel_err", &hll_union::get_rel_err,
          py::arg("upper_bound"), py::arg("unioned"), py::arg("lg_k"), py::arg("num_std_devs"))
     ;
 }


### PR DESCRIPTION
I think I got the public portions of hll.hpp changed. This can be extended to that whole file if we think it's warranted.