### PR TITLE
Fix windows compilation with MSVC 14 (VS 2015)

### DIFF
--- a/common/include/MurmurHash3.h
+++ b/common/include/MurmurHash3.h
@@ -20,7 +20,7 @@
 
 // Microsoft Visual Studio
 
-#if defined(_MSC_VER) && (_MSC_VER < 1600)
+#if defined(_MSC_VER)
 
 typedef unsigned char uint8_t;
 typedef unsigned int uint32_t;

--- a/cpc/include/common.h
+++ b/cpc/include/common.h
@@ -25,16 +25,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/time.h>
+#include <stdint.h>
 #include <time.h>
 #include <math.h>
 
 typedef int Boolean;
 
-typedef u_int8_t  U8;
-typedef u_int16_t U16;
-typedef u_int32_t U32;
-typedef u_int64_t U64;
+typedef uint8_t  U8;
+typedef uint16_t U16;
+typedef uint32_t U32;
+typedef uint64_t U64;
 
 typedef int16_t Short; // signed
 typedef int64_t Long;  // signed

--- a/cpc/include/cpc_sketch.hpp
+++ b/cpc/include/cpc_sketch.hpp
@@ -25,6 +25,11 @@
 #include <functional>
 #include <stdexcept>
 #include <cmath>
+#include <string>
+
+#if defined(_MSC_VER)
+#include <iso646.h> // for and/or keywords
+#endif // _MSC_VER
 
 #include "fm85.h"
 #include "fm85Compression.h"

--- a/cpc/include/cpc_union.hpp
+++ b/cpc/include/cpc_union.hpp
@@ -20,6 +20,12 @@
 #ifndef CPC_UNION_HPP_
 #define CPC_UNION_HPP_
 
+#include <string>
+
+#if defined(_MSC_VER)
+#include <iso646.h> // for and/or keywords
+#endif // _MSC_VER
+
 #include "fm85Merging.h"
 #include "cpc_sketch.hpp"
 

--- a/cpc/src/fm85.cpp
+++ b/cpc/src/fm85.cpp
@@ -252,7 +252,7 @@ void promoteSparseToWindowed (FM85 * self) {
 
   U8 * window = (U8 *) fm85alloc ((size_t) (k * sizeof(U8)));
   if (window == NULL) throw std::bad_alloc();
-  bzero ((void *) window, (size_t) k); // zero the memory (because we will be OR'ing into it)
+  memset ((void *) window,0, (size_t) k); // zero the memory (because we will be OR'ing into it)
 
   u32Table * newTable = u32TableMake (2, 6 + self->lgK);
 

--- a/cpc/src/fm85Compression.cpp
+++ b/cpc/src/fm85Compression.cpp
@@ -684,7 +684,7 @@ void uncompressHybridFlavor (FM85 * target, FM85 * source) {
 
   U8 * window = (U8 *) fm85alloc ((size_t) (k * sizeof(U8)));
   if (window == NULL) throw std::bad_alloc();
-  bzero ((void *) window, (size_t) k); // important: zero the memory
+  memset ((void *) window, 0, (size_t) k); // important: zero the memory
   
   Long nextTruePair = 0;
   Long i;

--- a/fi/include/reverse_purge_hash_map.hpp
+++ b/fi/include/reverse_purge_hash_map.hpp
@@ -25,6 +25,10 @@
 #include <iterator>
 #include <cmath>
 
+#if defined(_MSC_VER)
+#include <iso646.h> // for and/or keywords
+#endif // _MSC_VER
+
 namespace datasketches {
 
 /*

--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -27,6 +27,10 @@
 #include <functional>
 #include <cstring>
 
+#if defined(_MSC_VER)
+#include <iso646.h> // for and/or keywords
+#endif // _MSC_VER
+
 #include "kll_quantile_calculator.hpp"
 #include "kll_helper.hpp"
 #include "serde.hpp"

--- a/theta/include/binomial_bounds.hpp
+++ b/theta/include/binomial_bounds.hpp
@@ -23,6 +23,11 @@
 #include <algorithm>
 #include <cmath>
 
+#if defined(_MSC_VER)
+#include <iso646.h> // for and/or keywords
+#endif // _MSC_VER
+
+
 /*
  * This class enables the estimation of error bounds given a sample set size, the sampling
  * probability theta, the number of standard deviations and a simple noDataSeen flag. This can


### PR DESCRIPTION
Windows does not have the following things defined:

- `u_int8_t` and alikes: use the standard C defines `uint8_t` and alikes
- `sys/time.h`: not needed as far as I can see
- and/or keywords: provided by a header
- bzero: use memset instead, its cross-platform