### PR TITLE
return vector

### DIFF
--- a/cpc/include/cpc_common.hpp
+++ b/cpc/include/cpc_common.hpp
@@ -31,8 +31,6 @@ static const uint8_t CPC_MAX_LG_K = 26;
 static const uint8_t CPC_DEFAULT_LG_K = 11;
 static const uint64_t DEFAULT_SEED = 9001;
 
-typedef std::unique_ptr<void, std::function<void(void*)>> void_ptr_with_deleter;
-
 template<typename A> using AllocU8 = typename std::allocator_traits<A>::template rebind_alloc<uint8_t>;
 template<typename A> using AllocU16 = typename std::allocator_traits<A>::template rebind_alloc<uint16_t>;
 template<typename A> using AllocU32 = typename std::allocator_traits<A>::template rebind_alloc<uint32_t>;

--- a/cpc/include/cpc_sketch.hpp
+++ b/cpc/include/cpc_sketch.hpp
@@ -102,7 +102,7 @@ class cpc_sketch_alloc {
     vector_u8<A> serialize(unsigned header_size_bytes = 0) const;
 
     static cpc_sketch_alloc<A> deserialize(std::istream& is, uint64_t seed = DEFAULT_SEED);
-    static cpc_sketch_alloc<A> deserialize(const uint8_t* bytes, size_t size, uint64_t seed = DEFAULT_SEED);
+    static cpc_sketch_alloc<A> deserialize(const void* bytes, size_t size, uint64_t seed = DEFAULT_SEED);
 
     // for internal use
     uint32_t get_num_coupons() const;

--- a/cpc/include/cpc_sketch.hpp
+++ b/cpc/include/cpc_sketch.hpp
@@ -99,10 +99,10 @@ class cpc_sketch_alloc {
     void to_stream(std::ostream& os) const;
 
     void serialize(std::ostream& os) const;
-    std::pair<void_ptr_with_deleter, const size_t> serialize(unsigned header_size_bytes = 0) const;
+    vector_u8<A> serialize(unsigned header_size_bytes = 0) const;
 
     static cpc_sketch_alloc<A> deserialize(std::istream& is, uint64_t seed = DEFAULT_SEED);
-    static cpc_sketch_alloc<A> deserialize(const void* bytes, size_t size, uint64_t seed = DEFAULT_SEED);
+    static cpc_sketch_alloc<A> deserialize(const uint8_t* bytes, size_t size, uint64_t seed = DEFAULT_SEED);
 
     // for internal use
     uint32_t get_num_coupons() const;

--- a/cpc/include/cpc_sketch.hpp
+++ b/cpc/include/cpc_sketch.hpp
@@ -171,8 +171,6 @@ class cpc_sketch_alloc {
     static uint8_t get_preamble_ints(uint32_t num_coupons, bool has_hip, bool has_table, bool has_window);
     inline void write_hip(std::ostream& os) const;
     inline size_t copy_hip_to_mem(void* dst) const;
-    static inline size_t copy_to_mem(void* dst, const void* src, size_t size);
-    static inline size_t copy_from_mem(const void* src, void* dst, size_t size);
 
     friend cpc_compressor<A>;
     friend cpc_union_alloc<A>;

--- a/cpc/include/cpc_sketch_impl.hpp
+++ b/cpc/include/cpc_sketch_impl.hpp
@@ -586,8 +586,8 @@ cpc_sketch_alloc<A> cpc_sketch_alloc<A>::deserialize(std::istream& is, uint64_t 
 }
 
 template<typename A>
-cpc_sketch_alloc<A> cpc_sketch_alloc<A>::deserialize(const uint8_t* bytes, size_t size, uint64_t seed) {
-  const uint8_t* ptr = bytes;
+cpc_sketch_alloc<A> cpc_sketch_alloc<A>::deserialize(const void* bytes, size_t size, uint64_t seed) {
+  const char* ptr = static_cast<const char*>(bytes);
   uint8_t preamble_ints;
   ptr += copy_from_mem(ptr, &preamble_ints, sizeof(preamble_ints));
   uint8_t serial_version;
@@ -641,7 +641,7 @@ cpc_sketch_alloc<A> cpc_sketch_alloc<A>::deserialize(const uint8_t* bytes, size_
     }
     if (!has_window) compressed.table_num_entries = num_coupons;
   }
-  if (ptr != bytes + size) throw std::logic_error("deserialized size mismatch");
+  if (ptr != static_cast<const char*>(bytes) + size) throw std::logic_error("deserialized size mismatch");
 
   uint8_t expected_preamble_ints = get_preamble_ints(num_coupons, has_hip, has_table, has_window);
   if (preamble_ints != expected_preamble_ints) {

--- a/cpc/test/cpc_sketch_test.cpp
+++ b/cpc/test/cpc_sketch_test.cpp
@@ -226,8 +226,8 @@ class cpc_sketch_test: public CppUnit::TestFixture {
 
   void serialize_deserialize_empty_bytes() {
     cpc_sketch sketch(11);
-    auto data = sketch.serialize();
-    cpc_sketch deserialized = cpc_sketch::deserialize(data.first.get(), data.second);
+    auto bytes = sketch.serialize();
+    cpc_sketch deserialized = cpc_sketch::deserialize(bytes.data(), bytes.size());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), deserialized.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.get_estimate(), deserialized.get_estimate());
     CPPUNIT_ASSERT(deserialized.validate());
@@ -240,8 +240,8 @@ class cpc_sketch_test: public CppUnit::TestFixture {
     cpc_sketch sketch(11);
     const int n(200);
     for (int i = 0; i < n; i++) sketch.update(i);
-    auto data = sketch.serialize();
-    cpc_sketch deserialized = cpc_sketch::deserialize(data.first.get(), data.second);
+    auto bytes = sketch.serialize();
+    cpc_sketch deserialized = cpc_sketch::deserialize(bytes.data(), bytes.size());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), deserialized.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.get_estimate(), deserialized.get_estimate());
     CPPUNIT_ASSERT(deserialized.validate());
@@ -256,8 +256,8 @@ class cpc_sketch_test: public CppUnit::TestFixture {
     cpc_sketch sketch(11);
     const int n(100);
     for (int i = 0; i < n; i++) sketch.update(i);
-    auto data = sketch.serialize();
-    cpc_sketch deserialized = cpc_sketch::deserialize(data.first.get(), data.second);
+    auto bytes = sketch.serialize();
+    cpc_sketch deserialized = cpc_sketch::deserialize(bytes.data(), bytes.size());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), deserialized.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.get_estimate(), deserialized.get_estimate());
     CPPUNIT_ASSERT(deserialized.validate());
@@ -272,8 +272,8 @@ class cpc_sketch_test: public CppUnit::TestFixture {
     cpc_sketch sketch(11);
     const int n(2000);
     for (int i = 0; i < n; i++) sketch.update(i);
-    auto data = sketch.serialize();
-    cpc_sketch deserialized = cpc_sketch::deserialize(data.first.get(), data.second);
+    auto bytes = sketch.serialize();
+    cpc_sketch deserialized = cpc_sketch::deserialize(bytes.data(), bytes.size());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), deserialized.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.get_estimate(), deserialized.get_estimate());
     CPPUNIT_ASSERT(deserialized.validate());
@@ -290,8 +290,8 @@ class cpc_sketch_test: public CppUnit::TestFixture {
     cpc_sketch sketch(11);
     const int n(20000);
     for (int i = 0; i < n; i++) sketch.update(i);
-    auto data = sketch.serialize();
-    cpc_sketch deserialized = cpc_sketch::deserialize(data.first.get(), data.second);
+    auto bytes = sketch.serialize();
+    cpc_sketch deserialized = cpc_sketch::deserialize(bytes.data(), bytes.size());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), deserialized.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.get_estimate(), deserialized.get_estimate());
     CPPUNIT_ASSERT(deserialized.validate());
@@ -356,14 +356,14 @@ class cpc_sketch_test: public CppUnit::TestFixture {
     const int n(2000);
     for (int i = 0; i < n; i++) sketch.update(i);
     const int header_size_bytes = 4;
-    auto data(sketch.serialize(header_size_bytes));
+    auto bytes = sketch.serialize(header_size_bytes);
     std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
     sketch.serialize(s);
-    CPPUNIT_ASSERT_EQUAL(data.second - header_size_bytes, (size_t) s.tellp());
+    CPPUNIT_ASSERT_EQUAL(bytes.size() - header_size_bytes, (size_t) s.tellp());
 
     char* pp = new char[s.tellp()];
     s.read(pp, s.tellp());
-    CPPUNIT_ASSERT(std::memcmp(pp, static_cast<char*>(data.first.get()) + header_size_bytes, data.second - header_size_bytes) == 0);
+    CPPUNIT_ASSERT(std::memcmp(pp, bytes.data() + header_size_bytes, bytes.size() - header_size_bytes) == 0);
   }
 
   void update_int_equivalence() {

--- a/fi/test/frequent_items_sketch_test.cpp
+++ b/fi/test/frequent_items_sketch_test.cpp
@@ -284,8 +284,8 @@ class frequent_items_sketch_test: public CppUnit::TestFixture {
     sketch1.update(4, 4);
     sketch1.update(5, 5);
 
-    auto p = sketch1.serialize();
-    auto sketch2 = frequent_items_sketch<long long>::deserialize(p.first.get(), p.second);
+    auto bytes = sketch1.serialize();
+    auto sketch2 = frequent_items_sketch<long long>::deserialize(bytes.data(), bytes.size());
     CPPUNIT_ASSERT(!sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(15, (int) sketch2.get_total_weight());
     CPPUNIT_ASSERT_EQUAL(5U, sketch2.get_num_active_items());
@@ -325,8 +325,8 @@ class frequent_items_sketch_test: public CppUnit::TestFixture {
     sketch1.update("dddddddddddddddd", 4);
     sketch1.update("eeeeeeeeeeeeeeee", 5);
 
-    auto p = sketch1.serialize();
-    auto sketch2 = frequent_items_sketch<std::string>::deserialize(p.first.get(), p.second);
+    auto bytes = sketch1.serialize();
+    auto sketch2 = frequent_items_sketch<std::string>::deserialize(bytes.data(), bytes.size());
     CPPUNIT_ASSERT(!sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(15, (int) sketch2.get_total_weight());
     CPPUNIT_ASSERT_EQUAL(5U, sketch2.get_num_active_items());

--- a/hll/include/CouponList-internal.hpp
+++ b/hll/include/CouponList-internal.hpp
@@ -193,15 +193,10 @@ CouponList<A>* CouponList<A>::newList(std::istream& is) {
 }
 
 template<typename A>
-std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> CouponList<A>::serialize(bool compact, unsigned header_size_bytes) const {
+vector_u8<A> CouponList<A>::serialize(bool compact, unsigned header_size_bytes) const {
   const size_t sketchSizeBytes = (compact ? getCompactSerializationBytes() : getUpdatableSerializationBytes()) + header_size_bytes;
-  typedef typename std::allocator_traits<A>::template rebind_alloc<uint8_t> uint8Alloc;
-  std::unique_ptr<uint8_t, std::function<void(uint8_t*)>> byteArr(
-    uint8Alloc().allocate(sketchSizeBytes),
-    [sketchSizeBytes](uint8_t* p){ uint8Alloc().deallocate(p, sketchSizeBytes); }
-  );
-
-  uint8_t* bytes = byteArr.get() + header_size_bytes;
+  vector_u8<A> byteArr(sketchSizeBytes);
+  uint8_t* bytes = byteArr.data() + header_size_bytes;
 
   bytes[HllUtil<A>::PREAMBLE_INTS_BYTE] = static_cast<uint8_t>(getPreInts());
   bytes[HllUtil<A>::SER_VER_BYTE] = static_cast<uint8_t>(HllUtil<A>::SER_VER);
@@ -239,7 +234,7 @@ std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
       throw std::runtime_error("Impossible condition when serializing");
   }
 
-  return std::make_pair(std::move(byteArr), sketchSizeBytes);
+  return byteArr;
 }
 
 template<typename A>

--- a/hll/include/CouponList.hpp
+++ b/hll/include/CouponList.hpp
@@ -37,7 +37,7 @@ class CouponList : public HllSketchImpl<A> {
 
     static CouponList* newList(const void* bytes, size_t len);
     static CouponList* newList(std::istream& is);
-    virtual std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> serialize(bool compact, unsigned header_size_bytes) const;
+    virtual vector_u8<A> serialize(bool compact, unsigned header_size_bytes) const;
     virtual void serialize(std::ostream& os, bool compact) const;
 
     virtual ~CouponList();

--- a/hll/include/HllArray-internal.hpp
+++ b/hll/include/HllArray-internal.hpp
@@ -219,15 +219,10 @@ HllArray<A>* HllArray<A>::newHll(std::istream& is) {
 }
 
 template<typename A>
-std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> HllArray<A>::serialize(bool compact, unsigned header_size_bytes) const {
+vector_u8<A> HllArray<A>::serialize(bool compact, unsigned header_size_bytes) const {
   const size_t sketchSizeBytes = (compact ? getCompactSerializationBytes() : getUpdatableSerializationBytes()) + header_size_bytes;
-  typedef typename std::allocator_traits<A>::template rebind_alloc<uint8_t> uint8Alloc;
-  std::unique_ptr<uint8_t, std::function<void(uint8_t*)>> byteArr(
-    uint8Alloc().allocate(sketchSizeBytes),
-    [sketchSizeBytes](uint8_t* p){ uint8Alloc().deallocate(p, sketchSizeBytes); }
-    );
-
-  uint8_t* bytes = byteArr.get() + header_size_bytes;
+  vector_u8<A> byteArr(sketchSizeBytes);
+  uint8_t* bytes = byteArr.data() + header_size_bytes;
   AuxHashMap<A>* auxHashMap = getAuxHashMap();
 
   bytes[HllUtil<A>::PREAMBLE_INTS_BYTE] = static_cast<uint8_t>(getPreInts());
@@ -270,7 +265,7 @@ std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
     }
   }
 
-  return std::make_pair(std::move(byteArr), sketchSizeBytes);
+  return byteArr;
 }
 
 template<typename A>

--- a/hll/include/HllArray.hpp
+++ b/hll/include/HllArray.hpp
@@ -38,7 +38,7 @@ class HllArray : public HllSketchImpl<A> {
     static HllArray* newHll(const void* bytes, size_t len);
     static HllArray* newHll(std::istream& is);
 
-    virtual std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> serialize(bool compact, unsigned header_size_bytes) const;
+    virtual vector_u8<A> serialize(bool compact, unsigned header_size_bytes) const;
     virtual void serialize(std::ostream& os, bool compact) const;
 
     virtual ~HllArray();

--- a/hll/include/HllSketch-internal.hpp
+++ b/hll/include/HllSketch-internal.hpp
@@ -237,14 +237,12 @@ void hll_sketch_alloc<A>::serialize_updatable(std::ostream& os) const {
 }
 
 template<typename A>
-std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
-hll_sketch_alloc<A>::serialize_compact(unsigned header_size_bytes) const {
+vector_u8<A> hll_sketch_alloc<A>::serialize_compact(unsigned header_size_bytes) const {
   return sketch_impl->serialize(true, header_size_bytes);
 }
 
 template<typename A>
-std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t>
-hll_sketch_alloc<A>::serialize_updatable() const {
+vector_u8<A> hll_sketch_alloc<A>::serialize_updatable() const {
   return sketch_impl->serialize(false, 0);
 }
 

--- a/hll/include/HllSketchImpl.hpp
+++ b/hll/include/HllSketchImpl.hpp
@@ -35,7 +35,7 @@ class HllSketchImpl {
     virtual ~HllSketchImpl();
 
     virtual void serialize(std::ostream& os, bool compact) const = 0;
-    virtual std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> serialize(bool compact, unsigned header_size_bytes) const = 0;
+    virtual vector_u8<A> serialize(bool compact, unsigned header_size_bytes) const = 0;
 
     virtual HllSketchImpl* copy() const = 0;
     virtual HllSketchImpl* copyAs(target_hll_type tgtHllType) const = 0;

--- a/hll/include/HllUnion-internal.hpp
+++ b/hll/include/HllUnion-internal.hpp
@@ -151,12 +151,12 @@ void hll_union_alloc<A>::coupon_update(const int coupon) {
 }
 
 template<typename A>
-std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> hll_union_alloc<A>::serialize_compact() const {
+vector_u8<A> hll_union_alloc<A>::serialize_compact() const {
   return gadget.serialize_compact();
 }
 
 template<typename A>
-std::pair<std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>, const size_t> hll_union_alloc<A>::serialize_updatable() const {
+vector_u8<A> hll_union_alloc<A>::serialize_updatable() const {
   return gadget.serialize_updatable();
 }
 

--- a/hll/include/hll.hpp
+++ b/hll/include/hll.hpp
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <iostream>
+#include <vector>
 
 namespace datasketches {
 

--- a/hll/include/hll.hpp
+++ b/hll/include/hll.hpp
@@ -104,7 +104,8 @@ class HllSketchImpl;
 template<typename A>
 class hll_union_alloc;
 
-using byte_ptr_with_deleter = std::unique_ptr<uint8_t, std::function<void(uint8_t*)>>;
+template<typename A> using AllocU8 = typename std::allocator_traits<A>::template rebind_alloc<uint8_t>;
+template<typename A> using vector_u8 = std::vector<uint8_t, AllocU8<A>>;
 
 template<typename A = std::allocator<char> >
 class hll_sketch_alloc final {
@@ -167,13 +168,13 @@ class hll_sketch_alloc final {
      * where feasible to eliminate unused storage in the serialized image.
      * @param header_size_bytes Allows for PostgreSQL integration
      */
-    std::pair<byte_ptr_with_deleter, const size_t> serialize_compact(unsigned header_size_bytes = 0) const;
+    vector_u8<A> serialize_compact(unsigned header_size_bytes = 0) const;
 
     /**
      * Serializes the sketch to a byte array, retaining all internal 
      * data structures in their current form.
      */
-    std::pair<byte_ptr_with_deleter, const size_t> serialize_updatable() const;
+    vector_u8<A> serialize_updatable() const;
 
     /**
      * Serializes the sketch to an ostream, compacting data structures
@@ -553,13 +554,13 @@ class hll_union_alloc {
      * where feasible to eliminate unused storage in the serialized image.
      * @param header_size_bytes Allows for PostgreSQL integration
      */
-    std::pair<byte_ptr_with_deleter, const size_t> serialize_compact() const;
+    vector_u8<A> serialize_compact() const;
   
     /**
      * Serializes the sketch to a byte array, retaining all internal 
      * data structures in their current form.
      */
-    std::pair<byte_ptr_with_deleter, const size_t> serialize_updatable() const;
+    vector_u8<A> serialize_updatable() const;
 
     /**
      * Serializes the sketch to an ostream, compacting data structures

--- a/hll/test/CouponListTest.cpp
+++ b/hll/test/CouponListTest.cpp
@@ -134,40 +134,41 @@ class CouponListTest : public CppUnit::TestFixture {
     hll_sketch sk1(lgK);
     sk1.update(1);
     sk1.update(2);
-    std::pair<byte_ptr_with_deleter, const size_t> sketchBytes = sk1.serialize_compact();
-    uint8_t* bytes = sketchBytes.first.get();
+    auto sketchBytes = sk1.serialize_compact();
+    uint8_t* bytes = sketchBytes.data();
+    const size_t size = sketchBytes.size();
 
     bytes[HllUtil<>::PREAMBLE_INTS_BYTE] = 0;
     CPPUNIT_ASSERT_THROW_MESSAGE("Failed to detect error in preInts byte",
-                                 hll_sketch::deserialize(bytes, sketchBytes.second),
+                                 hll_sketch::deserialize(bytes, size),
                                  std::invalid_argument);
     CPPUNIT_ASSERT_THROW_MESSAGE("Failed to detect error in preInts byte",
-                                 CouponList<>::newList(bytes, sketchBytes.second),
+                                 CouponList<>::newList(bytes, size),
                                  std::invalid_argument);
 
     bytes[HllUtil<>::PREAMBLE_INTS_BYTE] = HllUtil<>::LIST_PREINTS;
 
     bytes[HllUtil<>::SER_VER_BYTE] = 0;
     CPPUNIT_ASSERT_THROW_MESSAGE("Failed to detect error in serialization version byte",
-                                 hll_sketch::deserialize(bytes, sketchBytes.second),
+                                 hll_sketch::deserialize(bytes, size),
                                  std::invalid_argument);
     bytes[HllUtil<>::SER_VER_BYTE] = HllUtil<>::SER_VER;
 
     bytes[HllUtil<>::FAMILY_BYTE] = 0;
     CPPUNIT_ASSERT_THROW_MESSAGE("Failed to detect error in family id byte",
-                                 hll_sketch::deserialize(bytes, sketchBytes.second),
+                                 hll_sketch::deserialize(bytes, size),
                                  std::invalid_argument);
     bytes[HllUtil<>::FAMILY_BYTE] = HllUtil<>::FAMILY_ID;
 
     uint8_t tmp = bytes[HllUtil<>::MODE_BYTE];
     bytes[HllUtil<>::MODE_BYTE] = 0x01; // HLL_4, SET
     CPPUNIT_ASSERT_THROW_MESSAGE("Failed to detect error in mode byte",
-                                 hll_sketch::deserialize(bytes, sketchBytes.second),
+                                 hll_sketch::deserialize(bytes, size),
                                  std::invalid_argument);
     bytes[HllUtil<>::MODE_BYTE] = tmp;
 
     CPPUNIT_ASSERT_THROW_MESSAGE("Failed to detect error in serialized length",
-                                 hll_sketch::deserialize(bytes, sketchBytes.second - 1),
+                                 hll_sketch::deserialize(bytes, size - 1),
                                  std::invalid_argument);
 
     CPPUNIT_ASSERT_THROW_MESSAGE("Failed to detect error in serialized length",

--- a/hll/test/HllUnionTest.cpp
+++ b/hll/test/HllUnionTest.cpp
@@ -225,8 +225,8 @@ class HllUnionTest : public CppUnit::TestFixture {
     hll_union dstU = hll_union::deserialize(ss);
     checkUnionEquality(srcU, dstU);
 
-    std::pair<byte_ptr_with_deleter, const size_t> bytes1 = srcU.serialize_compact();
-    dstU = hll_union::deserialize(bytes1.first.get(), bytes1.second);
+    auto bytes1 = srcU.serialize_compact();
+    dstU = hll_union::deserialize(bytes1.data(), bytes1.size());
     checkUnionEquality(srcU, dstU);
 
     ss.clear();
@@ -234,8 +234,8 @@ class HllUnionTest : public CppUnit::TestFixture {
     dstU = hll_union::deserialize(ss);
     checkUnionEquality(srcU, dstU);
 
-    std::pair<byte_ptr_with_deleter, const size_t> bytes2 = srcU.serialize_updatable();
-    dstU = hll_union::deserialize(bytes2.first.get(), bytes2.second);
+    auto bytes2 = srcU.serialize_updatable();
+    dstU = hll_union::deserialize(bytes2.data(), bytes2.size());
     checkUnionEquality(srcU, dstU);
   } 
 

--- a/hll/test/ToFromByteArrayTest.cpp
+++ b/hll/test/ToFromByteArrayTest.cpp
@@ -43,20 +43,20 @@ class ToFromByteArrayTest : public CppUnit::TestFixture {
     
     std::stringstream ss1;
     sk.serialize_updatable(ss1);
-    std::pair<byte_ptr_with_deleter, size_t> ser1 = sk.serialize_updatable();
+    auto ser1 = sk.serialize_updatable();
 
     std::stringstream ss;
     sk.serialize_updatable(ss);
     std::string str = ss.str();
 
 
-    hll_sketch sk2 = hll_sketch::deserialize(ser1.first.get(), ser1.second);
-    std::pair<byte_ptr_with_deleter, size_t> ser2 = sk.serialize_updatable();
+    hll_sketch sk2 = hll_sketch::deserialize(ser1.data(), ser1.size());
+    auto ser2 = sk.serialize_updatable();
 
-    CPPUNIT_ASSERT_EQUAL(ser1.second, ser2.second);
-    int len = ser1.second;
-    uint8_t* b1 = ser1.first.get();
-    uint8_t* b2 = ser2.first.get();
+    CPPUNIT_ASSERT_EQUAL(ser1.size(), ser2.size());
+    int len = ser1.size();
+    uint8_t* b1 = ser1.data();
+    uint8_t* b2 = ser2.data();
 
     for (int i = 0; i < len; ++i) {
       CPPUNIT_ASSERT_EQUAL(b1[i], b2[i]);
@@ -142,8 +142,8 @@ class ToFromByteArrayTest : public CppUnit::TestFixture {
     hll_sketch dst = hll_sketch::deserialize(ss);
     checkSketchEquality(src, dst);
 
-    std::pair<byte_ptr_with_deleter, const size_t> bytes1 = src.serialize_compact();
-    dst = hll_sketch::deserialize(bytes1.first.get(), bytes1.second);
+    auto bytes1 = src.serialize_compact();
+    dst = hll_sketch::deserialize(bytes1.data(), bytes1.size());
     checkSketchEquality(src, dst);
 
     ss.clear();
@@ -151,8 +151,8 @@ class ToFromByteArrayTest : public CppUnit::TestFixture {
     dst = hll_sketch::deserialize(ss);
     checkSketchEquality(src, dst);
 
-    std::pair<byte_ptr_with_deleter, const size_t> bytes2 = src.serialize_updatable();
-    dst = hll_sketch::deserialize(bytes2.first.get(), bytes2.second);
+    auto bytes2 = src.serialize_updatable();
+    dst = hll_sketch::deserialize(bytes2.data(), bytes2.size());
     checkSketchEquality(src, dst);
   }
 

--- a/kll/test/kll_sketch_custom_type_test.cpp
+++ b/kll/test/kll_sketch_custom_type_test.cpp
@@ -54,7 +54,7 @@ public:
     CPPUNIT_ASSERT_THROW(sketch.get_quantile(0), std::runtime_error);
     CPPUNIT_ASSERT_THROW(sketch.get_min_value(), std::runtime_error);
     CPPUNIT_ASSERT_THROW(sketch.get_max_value(), std::runtime_error);
-    CPPUNIT_ASSERT_EQUAL(8u, sketch.get_serialized_size_bytes());
+    CPPUNIT_ASSERT_EQUAL((size_t) 8, sketch.get_serialized_size_bytes());
 
     sketch.update(1);
     sketch.update(2);
@@ -132,9 +132,9 @@ public:
 
     std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
     sketch1.serialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch1.get_serialized_size_bytes(), (uint32_t) s.tellp());
+    CPPUNIT_ASSERT_EQUAL(sketch1.get_serialized_size_bytes(), (size_t) s.tellp());
     auto sketch2 = kll_test_type_sketch::deserialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) s.tellg());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (size_t) s.tellg());
     CPPUNIT_ASSERT_EQUAL(s.tellp(), s.tellg());
     CPPUNIT_ASSERT_EQUAL(sketch1.is_empty(), sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch1.is_estimation_mode(), sketch2.is_estimation_mode());

--- a/kll/test/kll_sketch_test.cpp
+++ b/kll/test/kll_sketch_test.cpp
@@ -103,10 +103,10 @@ public:
     CPPUNIT_ASSERT(std::isnan(sketch.get_max_value()));
     CPPUNIT_ASSERT(std::isnan(sketch.get_quantile(0.5)));
     const double fractions[3] {0, 0.5, 1};
-    CPPUNIT_ASSERT(!sketch.get_quantiles(fractions, 3));
+    CPPUNIT_ASSERT_EQUAL(0, (int) sketch.get_quantiles(fractions, 3).size());
     const float split_points[1] {0};
-    CPPUNIT_ASSERT(!sketch.get_PMF(split_points, 1));
-    CPPUNIT_ASSERT(!sketch.get_CDF(split_points, 1));
+    CPPUNIT_ASSERT_EQUAL(0, (int) sketch.get_PMF(split_points, 1).size());
+    CPPUNIT_ASSERT_EQUAL(0, (int) sketch.get_CDF(split_points, 1).size());
 
     int count = 0;
     for (auto& it: sketch) {
@@ -135,8 +135,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(1.0f, sketch.get_max_value());
     CPPUNIT_ASSERT_EQUAL(1.0f, sketch.get_quantile(0.5));
     const double fractions[3] {0, 0.5, 1};
-    auto quantiles(sketch.get_quantiles(fractions, 3));
-    CPPUNIT_ASSERT(quantiles);
+    auto quantiles = sketch.get_quantiles(fractions, 3);
+    CPPUNIT_ASSERT_EQUAL(3, (int) quantiles.size());
     CPPUNIT_ASSERT_EQUAL(1.0f, quantiles[0]);
     CPPUNIT_ASSERT_EQUAL(1.0f, quantiles[1]);
     CPPUNIT_ASSERT_EQUAL(1.0f, quantiles[2]);
@@ -165,8 +165,8 @@ public:
     CPPUNIT_ASSERT_EQUAL((float) n - 1, sketch.get_quantile(1));
 
     const double fractions[3] {0, 0.5, 1};
-    auto quantiles(sketch.get_quantiles(fractions, 3));
-    CPPUNIT_ASSERT(quantiles);
+    auto quantiles = sketch.get_quantiles(fractions, 3);
+    CPPUNIT_ASSERT_EQUAL(3, (int) quantiles.size());
     CPPUNIT_ASSERT_EQUAL(0.0f, quantiles[0]);
     CPPUNIT_ASSERT_EQUAL((float) n / 2, quantiles[1]);
     CPPUNIT_ASSERT_EQUAL((float) n - 1 , quantiles[2]);
@@ -256,9 +256,9 @@ public:
     kll_float_sketch sketch;
     std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
     sketch.serialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (uint32_t) s.tellp());
+    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (size_t) s.tellp());
     auto sketch2 = kll_float_sketch::deserialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) s.tellg());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (size_t) s.tellg());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.is_estimation_mode(), sketch2.is_estimation_mode());
     CPPUNIT_ASSERT_EQUAL(sketch.get_n(), sketch2.get_n());
@@ -274,9 +274,9 @@ public:
     sketch.update(1);
     std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
     sketch.serialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (uint32_t) s.tellp());
+    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (size_t) s.tellp());
     auto sketch2 = kll_float_sketch::deserialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) s.tellg());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (size_t) s.tellg());
     CPPUNIT_ASSERT_EQUAL(s.tellp(), s.tellg());
     CPPUNIT_ASSERT(!sketch2.is_empty());
     CPPUNIT_ASSERT(!sketch2.is_estimation_mode());
@@ -308,9 +308,9 @@ public:
     for (int i = 0; i < n; i++) sketch.update(i);
     std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
     sketch.serialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (uint32_t) s.tellp());
+    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (size_t) s.tellp());
     auto sketch2 = kll_float_sketch::deserialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) s.tellg());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (size_t) s.tellg());
     CPPUNIT_ASSERT_EQUAL(s.tellp(), s.tellg());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.is_estimation_mode(), sketch2.is_estimation_mode());
@@ -329,10 +329,10 @@ public:
     kll_float_sketch sketch;
     const int n(1000);
     for (int i = 0; i < n; i++) sketch.update(i);
-    auto data = sketch.serialize();
-    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (uint32_t) data.second);
-    auto sketch2 = kll_float_sketch::deserialize(data.first.get(), data.second);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) data.second);
+    auto bytes = sketch.serialize();
+    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), bytes.size());
+    auto sketch2 = kll_float_sketch::deserialize(bytes.data(), bytes.size());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), bytes.size());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.is_estimation_mode(), sketch2.is_estimation_mode());
     CPPUNIT_ASSERT_EQUAL(sketch.get_n(), sketch2.get_n());
@@ -487,9 +487,9 @@ public:
 
     std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
     sketch.serialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (uint32_t) s.tellp());
+    CPPUNIT_ASSERT_EQUAL(sketch.get_serialized_size_bytes(), (size_t) s.tellp());
     auto sketch2 = kll_sketch<int>::deserialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) s.tellg());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (size_t) s.tellg());
     CPPUNIT_ASSERT_EQUAL(s.tellp(), s.tellg());
     CPPUNIT_ASSERT_EQUAL(sketch.is_empty(), sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch.is_estimation_mode(), sketch2.is_estimation_mode());
@@ -509,7 +509,7 @@ public:
     CPPUNIT_ASSERT_THROW(sketch1.get_quantile(0), std::runtime_error);
     CPPUNIT_ASSERT_THROW(sketch1.get_min_value(), std::runtime_error);
     CPPUNIT_ASSERT_THROW(sketch1.get_max_value(), std::runtime_error);
-    CPPUNIT_ASSERT_EQUAL(8u, sketch1.get_serialized_size_bytes());
+    CPPUNIT_ASSERT_EQUAL((size_t) 8, sketch1.get_serialized_size_bytes());
 
     const int n = 1000;
     for (int i = 0; i < n; i++) sketch1.update(std::to_string(i));
@@ -519,9 +519,9 @@ public:
 
     std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
     sketch1.serialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch1.get_serialized_size_bytes(), (uint32_t) s.tellp());
+    CPPUNIT_ASSERT_EQUAL(sketch1.get_serialized_size_bytes(), (size_t) s.tellp());
     auto sketch2 = kll_string_sketch::deserialize(s);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) s.tellg());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (size_t) s.tellg());
     CPPUNIT_ASSERT_EQUAL(s.tellp(), s.tellg());
     CPPUNIT_ASSERT_EQUAL(sketch1.is_empty(), sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch1.is_estimation_mode(), sketch2.is_estimation_mode());
@@ -548,7 +548,7 @@ public:
     CPPUNIT_ASSERT_THROW(sketch1.get_quantile(0), std::runtime_error);
     CPPUNIT_ASSERT_THROW(sketch1.get_min_value(), std::runtime_error);
     CPPUNIT_ASSERT_THROW(sketch1.get_max_value(), std::runtime_error);
-    CPPUNIT_ASSERT_EQUAL(8u, sketch1.get_serialized_size_bytes());
+    CPPUNIT_ASSERT_EQUAL((size_t) 8, sketch1.get_serialized_size_bytes());
 
     const int n = 1000;
     for (int i = 0; i < n; i++) sketch1.update(std::to_string(i));
@@ -556,10 +556,10 @@ public:
     CPPUNIT_ASSERT_EQUAL(std::string("0"), sketch1.get_min_value());
     CPPUNIT_ASSERT_EQUAL(std::string("999"), sketch1.get_max_value());
 
-    auto data = sketch1.serialize();
-    CPPUNIT_ASSERT_EQUAL((size_t) sketch1.get_serialized_size_bytes(), data.second);
-    auto sketch2 = kll_string_sketch::deserialize(data.first.get(), data.second);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) data.second);
+    auto bytes = sketch1.serialize();
+    CPPUNIT_ASSERT_EQUAL(sketch1.get_serialized_size_bytes(), bytes.size());
+    auto sketch2 = kll_string_sketch::deserialize(bytes.data(), bytes.size());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), bytes.size());
     CPPUNIT_ASSERT_EQUAL(sketch1.is_empty(), sketch2.is_empty());
     CPPUNIT_ASSERT_EQUAL(sketch1.is_estimation_mode(), sketch2.is_estimation_mode());
     CPPUNIT_ASSERT_EQUAL(sketch1.get_n(), sketch2.get_n());
@@ -577,10 +577,10 @@ public:
   void sketch_of_strings_single_item_bytes() {
     kll_string_sketch sketch1;
     sketch1.update("a");
-    auto data = sketch1.serialize();
-    CPPUNIT_ASSERT_EQUAL((size_t) sketch1.get_serialized_size_bytes(), data.second);
-    auto sketch2 = kll_string_sketch::deserialize(data.first.get(), data.second);
-    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), (uint32_t) data.second);
+    auto bytes = sketch1.serialize();
+    CPPUNIT_ASSERT_EQUAL(sketch1.get_serialized_size_bytes(), bytes.size());
+    auto sketch2 = kll_string_sketch::deserialize(bytes.data(), bytes.size());
+    CPPUNIT_ASSERT_EQUAL(sketch2.get_serialized_size_bytes(), bytes.size());
   }
 
   void copy() {

--- a/python/src/cpc_wrapper.cpp
+++ b/python/src/cpc_wrapper.cpp
@@ -37,7 +37,7 @@ cpc_sketch* cpc_sketch_deserialize(py::bytes skBytes) {
 
 py::object cpc_sketch_serialize(const cpc_sketch& sk) {
   auto serResult = sk.serialize();
-  return py::bytes((char*)serResult.first.get(), serResult.second);
+  return py::bytes((char*)serResult.data(), serResult.size());
 }
 
 std::string cpc_sketch_to_string(const cpc_sketch& sk) {

--- a/python/src/fi_wrapper.cpp
+++ b/python/src/fi_wrapper.cpp
@@ -36,7 +36,7 @@ frequent_items_sketch<T> fi_sketch_deserialize(py::bytes skBytes) {
 template<typename T>
 py::object fi_sketch_serialize(const frequent_items_sketch<T>& sk) {
   auto serResult = sk.serialize();
-  return py::bytes((char*)serResult.first.get(), serResult.second);
+  return py::bytes((char*)serResult.data(), serResult.size());
 }
 
 // maybe possible to disambiguate the static vs method get_epsilon calls, but

--- a/python/src/hll_wrapper.cpp
+++ b/python/src/hll_wrapper.cpp
@@ -33,12 +33,12 @@ hll_sketch hll_sketch_deserialize(py::bytes skBytes) {
 
 py::object hll_sketch_serialize_compact(const hll_sketch& sk) {
   auto serResult = sk.serialize_compact();
-  return py::bytes((char*)serResult.first.get(), serResult.second);
+  return py::bytes((char*)serResult.data(), serResult.size());
 }
 
 py::object hll_sketch_serialize_updatable(const hll_sketch& sk) {
   auto serResult = sk.serialize_updatable();
-  return py::bytes((char*)serResult.first.get(), serResult.second);
+  return py::bytes((char*)serResult.data(), serResult.size());
 }
 
 hll_union hll_union_deserialize(py::bytes uBytes) {
@@ -48,12 +48,12 @@ hll_union hll_union_deserialize(py::bytes uBytes) {
 
 py::object hll_union_serialize_compact(const hll_union& u) {
   auto serResult = u.serialize_compact();
-  return py::bytes((char*)serResult.first.get(), serResult.second);
+  return py::bytes((char*)serResult.data(), serResult.size());
 }
 
 py::object hll_union_serialize_updatable(const hll_union& u) {
   auto serResult = u.serialize_updatable();
-  return py::bytes((char*)serResult.first.get(), serResult.second);
+  return py::bytes((char*)serResult.data(), serResult.size());
 }
 
 }

--- a/python/src/kll_wrapper.cpp
+++ b/python/src/kll_wrapper.cpp
@@ -37,7 +37,7 @@ kll_sketch<T> kll_sketch_deserialize(py::bytes skBytes) {
 template<typename T>
 py::object kll_sketch_serialize(const kll_sketch<T>& sk) {
   auto serResult = sk.serialize();
-  return py::bytes((char*)serResult.first.get(), serResult.second);
+  return py::bytes((char*)serResult.data(), serResult.size());
 }
 
 // maybe possible to disambiguate the static vs method rank error calls, but

--- a/python/src/theta_wrapper.cpp
+++ b/python/src/theta_wrapper.cpp
@@ -54,7 +54,7 @@ theta_sketch* theta_sketch_deserialize(py::bytes skBytes,
 
 py::object theta_sketch_serialize(const theta_sketch& sk) {
   auto serResult = sk.serialize();
-  return py::bytes((char*)serResult.first.get(), serResult.second);
+  return py::bytes((char*)serResult.data(), serResult.size());
 }
 
 std::string theta_sketch_to_string(const theta_sketch& sk,

--- a/theta/include/theta_sketch.hpp
+++ b/theta/include/theta_sketch.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <functional>
 #include <climits>
+#include <vector>
 
 namespace datasketches {
 
@@ -41,7 +42,8 @@ template<typename A> class theta_intersection_alloc;
 template<typename A> class theta_a_not_b_alloc;
 
 // for serialization as raw bytes
-typedef std::unique_ptr<void, std::function<void(void*)>> void_ptr_with_deleter;
+template<typename A> using AllocU8 = typename std::allocator_traits<A>::template rebind_alloc<uint8_t>;
+template<typename A> using vector_u8 = std::vector<uint8_t, AllocU8<A>>;
 
 template<typename A>
 class theta_sketch_alloc {
@@ -70,7 +72,7 @@ public:
   virtual bool is_ordered() const = 0;
   virtual void to_stream(std::ostream& os, bool print_items = false) const = 0;
   virtual void serialize(std::ostream& os) const = 0;
-  virtual std::pair<void_ptr_with_deleter, const size_t> serialize(unsigned header_size_bytes = 0) const = 0;
+  virtual vector_u8<A> serialize(unsigned header_size_bytes = 0) const = 0;
 
   typedef std::unique_ptr<theta_sketch_alloc<A>, std::function<void(theta_sketch_alloc<A>*)>> unique_ptr;
   static unique_ptr deserialize(std::istream& is, uint64_t seed = update_theta_sketch_alloc<A>::builder::DEFAULT_SEED);
@@ -119,7 +121,7 @@ public:
   virtual void to_stream(std::ostream& os, bool print_items = false) const;
   virtual void serialize(std::ostream& os) const;
   // header space is reserved, but not initialized
-  virtual std::pair<void_ptr_with_deleter, const size_t> serialize(unsigned header_size_bytes = 0) const;
+  virtual vector_u8<A> serialize(unsigned header_size_bytes = 0) const;
 
   void update(const std::string& value);
   void update(uint64_t value);
@@ -218,7 +220,7 @@ public:
   virtual void to_stream(std::ostream& os, bool print_items = false) const;
   virtual void serialize(std::ostream& os) const;
   // header space is reserved, but not initialized
-  virtual std::pair<void_ptr_with_deleter, const size_t> serialize(unsigned header_size_bytes = 0) const;
+  virtual vector_u8<A> serialize(unsigned header_size_bytes = 0) const;
 
   virtual typename theta_sketch_alloc<A>::const_iterator begin() const;
   virtual typename theta_sketch_alloc<A>::const_iterator end() const;

--- a/theta/test/theta_sketch_test.cpp
+++ b/theta/test/theta_sketch_test.cpp
@@ -334,18 +334,18 @@ class theta_sketch_test: public CppUnit::TestFixture {
     {
       std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
       update_sketch.serialize(s);
-      auto data = update_sketch.serialize();
-      CPPUNIT_ASSERT_EQUAL((size_t) s.tellp(), data.second);
-      for (size_t i = 0; i < data.second; ++i) {
-        CPPUNIT_ASSERT_EQUAL((char)s.get(), ((char*)data.first.get())[i]);
+      auto bytes = update_sketch.serialize();
+      CPPUNIT_ASSERT_EQUAL((size_t) s.tellp(), bytes.size());
+      for (size_t i = 0; i < bytes.size(); ++i) {
+        CPPUNIT_ASSERT_EQUAL((char)s.get(), ((char*)bytes.data())[i]);
       }
 
       // deserialize as base class
       {
         s.seekg(0); // rewind
         auto deserialized_sketch_ptr1 = theta_sketch::deserialize(s);
-        auto deserialized_sketch_ptr2 = theta_sketch::deserialize(data.first.get(), data.second);
-        CPPUNIT_ASSERT_EQUAL(data.second, (size_t) s.tellg());
+        auto deserialized_sketch_ptr2 = theta_sketch::deserialize(bytes.data(), bytes.size());
+        CPPUNIT_ASSERT_EQUAL(bytes.size(), (size_t) s.tellg());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch_ptr1->is_empty(), deserialized_sketch_ptr2->is_empty());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch_ptr1->is_ordered(), deserialized_sketch_ptr2->is_ordered());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch_ptr1->get_num_retained(), deserialized_sketch_ptr2->get_num_retained());
@@ -365,8 +365,8 @@ class theta_sketch_test: public CppUnit::TestFixture {
       {
         s.seekg(0); // rewind
         update_theta_sketch deserialized_sketch1 = update_theta_sketch::deserialize(s);
-        update_theta_sketch deserialized_sketch2 = update_theta_sketch::deserialize(data.first.get(), data.second);
-        CPPUNIT_ASSERT_EQUAL(data.second, (size_t) s.tellg());
+        update_theta_sketch deserialized_sketch2 = update_theta_sketch::deserialize(bytes.data(), bytes.size());
+        CPPUNIT_ASSERT_EQUAL(bytes.size(), (size_t) s.tellg());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch1.is_empty(), deserialized_sketch2.is_empty());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch1.is_ordered(), deserialized_sketch2.is_ordered());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch1.get_num_retained(), deserialized_sketch2.get_num_retained());
@@ -387,18 +387,18 @@ class theta_sketch_test: public CppUnit::TestFixture {
     {
       std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
       update_sketch.compact().serialize(s);
-      auto data = update_sketch.compact().serialize();
-      CPPUNIT_ASSERT_EQUAL((size_t) s.tellp(), data.second);
-      for (size_t i = 0; i < data.second; ++i) {
-        CPPUNIT_ASSERT_EQUAL((char)s.get(), ((char*)data.first.get())[i]);
+      auto bytes = update_sketch.compact().serialize();
+      CPPUNIT_ASSERT_EQUAL((size_t) s.tellp(), bytes.size());
+      for (size_t i = 0; i < bytes.size(); ++i) {
+        CPPUNIT_ASSERT_EQUAL((char)s.get(), ((char*)bytes.data())[i]);
       }
 
       // deserialize as base class
       {
         s.seekg(0); // rewind
         auto deserialized_sketch_ptr1 = theta_sketch::deserialize(s);
-        auto deserialized_sketch_ptr2 = theta_sketch::deserialize(data.first.get(), data.second);
-        CPPUNIT_ASSERT_EQUAL(data.second, (size_t) s.tellg());
+        auto deserialized_sketch_ptr2 = theta_sketch::deserialize(bytes.data(), bytes.size());
+        CPPUNIT_ASSERT_EQUAL(bytes.size(), (size_t) s.tellg());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch_ptr1->is_empty(), deserialized_sketch_ptr2->is_empty());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch_ptr1->is_ordered(), deserialized_sketch_ptr2->is_ordered());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch_ptr1->get_num_retained(), deserialized_sketch_ptr2->get_num_retained());
@@ -418,8 +418,8 @@ class theta_sketch_test: public CppUnit::TestFixture {
       {
         s.seekg(0); // rewind
         compact_theta_sketch deserialized_sketch1 = compact_theta_sketch::deserialize(s);
-        compact_theta_sketch deserialized_sketch2 = compact_theta_sketch::deserialize(data.first.get(), data.second);
-        CPPUNIT_ASSERT_EQUAL(data.second, (size_t) s.tellg());
+        compact_theta_sketch deserialized_sketch2 = compact_theta_sketch::deserialize(bytes.data(), bytes.size());
+        CPPUNIT_ASSERT_EQUAL(bytes.size(), (size_t) s.tellg());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch1.is_empty(), deserialized_sketch2.is_empty());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch1.is_ordered(), deserialized_sketch2.is_ordered());
         CPPUNIT_ASSERT_EQUAL(deserialized_sketch1.get_num_retained(), deserialized_sketch2.get_num_retained());


### PR DESCRIPTION
Changes:
- return vector from serialize
- return vector from KLL get_quantiles, get_PMF and get_CDF
- use common copy_from_mem and copy_to_mem from serde.hpp