### PR TITLE
Add missing include in CPC compression test

### DIFF
--- a/cpc/test/compression_test.cpp
+++ b/cpc/test/compression_test.cpp
@@ -19,6 +19,7 @@
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include <algorithm>
 
 #include "cpc_compressor.hpp"
 


### PR DESCRIPTION
Hello,

I ran into an issue when running the tests for the library. It seems just a simple include missing from a test.

```...
[ 54%] Building CXX object cpc/test/CMakeFiles/cpc_test.dir/compression_test.cpp.o
/data/fork-datasketch/cpc/test/compression_test.cpp: In member function ‘void datasketches::compression_test::compress_and_uncompress_pairs()’:
/data/fork-datasketch/cpc/test/compression_test.cpp:51:5: error: ‘sort’ is not a member of ‘std’
     std::sort(pairArray, &pairArray[N]);
     ^
cpc/test/CMakeFiles/cpc_test.dir/build.make:88: recipe for target 'cpc/test/CMakeFiles/cpc_test.dir/compression_test.cpp.o' failed
make[2]: *** [cpc/test/CMakeFiles/cpc_test.dir/compression_test.cpp.o] Error 1
CMakeFiles/Makefile2:285: recipe for target 'cpc/test/CMakeFiles/cpc_test.dir/all' failed
make[1]: *** [cpc/test/CMakeFiles/cpc_test.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
```

Note that I get this issue on my local machine (Ubuntu, gcc 5.4) but it works in a Docker with gcc 4.8.5.

This PR should fix it.