### PR TITLE
include pybind via https rather than ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "python/pybind11"]
 	path = python/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11


### PR DESCRIPTION
also moves to latest pybiind version

note that python tests won't work for this branch in isolation since it's based on master, without the frequent items python fix