### PR TITLE
frequent items weight type as a template parameter

### DIFF
--- a/fi/include/frequent_items_sketch.hpp
+++ b/fi/include/frequent_items_sketch.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <iostream>
 #include <functional>
+#include <type_traits>
 
 #include "reverse_purge_hash_map.hpp"
 #include "serde.hpp"
@@ -89,12 +90,16 @@ private:
   static void check_family_id(uint8_t family_id);
   static void check_size(uint8_t lg_cur_size, uint8_t lg_max_size);
 
-  // version for signed type
-  template<typename WW = W, typename std::enable_if<std::is_signed<WW>::value, int>::type = 0>
+  // version for integral signed type
+  template<typename WW = W, typename std::enable_if<std::is_integral<WW>::value && std::is_signed<WW>::value, int>::type = 0>
   static inline void check_weight(WW weight);
 
-  // version for unsigned type
-  template<typename WW = W, typename std::enable_if<std::is_unsigned<WW>::value, int>::type = 0>
+  // version for integral unsigned type
+  template<typename WW = W, typename std::enable_if<std::is_integral<WW>::value && std::is_unsigned<WW>::value, int>::type = 0>
+  static inline void check_weight(WW weight);
+
+  // version for floating point type
+  template<typename WW = W, typename std::enable_if<std::is_floating_point<WW>::value, int>::type = 0>
   static inline void check_weight(WW weight);
 };
 

--- a/fi/include/frequent_items_sketch_impl.hpp
+++ b/fi/include/frequent_items_sketch_impl.hpp
@@ -470,7 +470,7 @@ void frequent_items_sketch<T, W, H, E, S, A>::check_weight(WW weight) {
   if (std::isnan(weight)) {
     throw std::invalid_argument("weight must be a valid number");
   }
-  if (weight > std::numeric_limits<WW>::max()) {
+  if (std::isinf(weight)) {
     throw std::invalid_argument("weight must be finite");
   }
 }

--- a/fi/include/frequent_items_sketch_impl.hpp
+++ b/fi/include/frequent_items_sketch_impl.hpp
@@ -22,6 +22,7 @@
 
 #include <streambuf>
 #include <cstring>
+#include <limits>
 
 namespace datasketches {
 
@@ -445,18 +446,34 @@ void frequent_items_sketch<T, W, H, E, S, A>::to_stream(std::ostream& os, bool p
   }
 }
 
+// version for integral signed type
 template<typename T, typename W, typename H, typename E, typename S, typename A>
-template<typename WW, typename std::enable_if<std::is_signed<WW>::value, int>::type>
+template<typename WW, typename std::enable_if<std::is_integral<WW>::value && std::is_signed<WW>::value, int>::type>
 void frequent_items_sketch<T, W, H, E, S, A>::check_weight(WW weight) {
   if (weight < 0) {
     throw std::invalid_argument("weight must be non-negative");
   }
 }
 
-// no-op for unsigned types
+// version for integral unsigned type - no-op
 template<typename T, typename W, typename H, typename E, typename S, typename A>
-template<typename WW, typename std::enable_if<std::is_unsigned<WW>::value, int>::type>
+template<typename WW, typename std::enable_if<std::is_integral<WW>::value && std::is_unsigned<WW>::value, int>::type>
 void frequent_items_sketch<T, W, H, E, S, A>::check_weight(WW weight) {}
+
+// version for floating point type
+template<typename T, typename W, typename H, typename E, typename S, typename A>
+template<typename WW, typename std::enable_if<std::is_floating_point<WW>::value, int>::type>
+void frequent_items_sketch<T, W, H, E, S, A>::check_weight(WW weight) {
+  if (weight < 0) {
+    throw std::invalid_argument("weight must be non-negative");
+  }
+  if (std::isnan(weight)) {
+    throw std::invalid_argument("weight must be a valid number");
+  }
+  if (weight > std::numeric_limits<WW>::max()) {
+    throw std::invalid_argument("weight must be finite");
+  }
+}
 
 }
 

--- a/fi/include/reverse_purge_hash_map.hpp
+++ b/fi/include/reverse_purge_hash_map.hpp
@@ -26,6 +26,8 @@
 namespace datasketches {
 
 /*
+ * This is a specialized linear-probing hash map with a reverse purge operation
+ * that removes all entries in the map with values that are less than zero.
  * Based on Java implementation here:
  * https://github.com/DataSketches/sketches-core/blob/master/src/main/java/com/yahoo/sketches/frequencies/ReversePurgeItemHashMap.java
  * author Alexander Saydakov
@@ -109,4 +111,4 @@ private:
 
 #include "reverse_purge_hash_map_impl.hpp"
 
-# endif
+#endif

--- a/fi/test/frequent_items_sketch_custom_type_test.cpp
+++ b/fi/test/frequent_items_sketch_custom_type_test.cpp
@@ -25,13 +25,14 @@
 
 namespace datasketches {
 
-typedef frequent_items_sketch<test_type, test_type_hash, test_type_equal, test_type_serde> frequent_test_type_sketch;
+typedef frequent_items_sketch<test_type, float, test_type_hash, test_type_equal, test_type_serde> frequent_test_type_sketch;
 
 class frequent_items_sketch_custom_type_test: public CppUnit::TestFixture {
 
   CPPUNIT_TEST_SUITE(frequent_items_sketch_custom_type_test);
   CPPUNIT_TEST(custom_type);
   CPPUNIT_TEST(moving_merge);
+  CPPUNIT_TEST(negative_weight);
   CPPUNIT_TEST_SUITE_END();
 
   void custom_type() {
@@ -68,7 +69,7 @@ class frequent_items_sketch_custom_type_test: public CppUnit::TestFixture {
     CPPUNIT_ASSERT_EQUAL(sketch.get_maximum_error(), sketch2.get_maximum_error());
     //std::cerr << "end" << std::endl;
 
-    //sketch2.to_stream(std::cerr, true);
+    sketch2.to_stream(std::cerr, true);
   }
 
   // this is to see the debug print from test_type if enabled there to make sure items are moved
@@ -81,6 +82,11 @@ class frequent_items_sketch_custom_type_test: public CppUnit::TestFixture {
 
     sketch2.merge(std::move(sketch1));
     CPPUNIT_ASSERT_EQUAL(2, (int) sketch2.get_total_weight());
+  }
+
+  void negative_weight() {
+    frequent_test_type_sketch sketch(3);
+    CPPUNIT_ASSERT_THROW(sketch.update(1, -1), std::invalid_argument);
   }
 
 };


### PR DESCRIPTION
This will allow changing the type for weights from uint64_t. For instance, something smaller such as uint32_t or float.