### PR TITLE
this should not be needed anymore

### DIFF
--- a/cpc/include/cpc_sketch.hpp
+++ b/cpc/include/cpc_sketch.hpp
@@ -25,10 +25,6 @@
 #include <string>
 #include <vector>
 
-#if defined(_MSC_VER)
-#include <iso646.h> // for and/or keywords
-#endif // _MSC_VER
-
 #include "u32_table.hpp"
 #include "cpc_common.hpp"
 #include "cpc_compressor.hpp"

--- a/cpc/include/cpc_union.hpp
+++ b/cpc/include/cpc_union.hpp
@@ -22,10 +22,6 @@
 
 #include <string>
 
-#if defined(_MSC_VER)
-#include <iso646.h> // for and/or keywords
-#endif // _MSC_VER
-
 #include "cpc_sketch.hpp"
 
 namespace datasketches {

--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -24,10 +24,6 @@
 #include <memory>
 #include <vector>
 
-#if defined(_MSC_VER)
-#include <iso646.h> // for and/or keywords
-#endif // _MSC_VER
-
 #include "kll_quantile_calculator.hpp"
 #include "serde.hpp"
 


### PR DESCRIPTION
forgot to remove this a while ago when switched to standard && and || operators