### PR TITLE
Memory fixes

### DIFF
--- a/cpc/include/cpc_union_impl.hpp
+++ b/cpc/include/cpc_union_impl.hpp
@@ -28,12 +28,13 @@ template<typename A>
 cpc_union_alloc<A>::cpc_union_alloc(uint8_t lg_k, uint64_t seed):
 lg_k(lg_k),
 seed(seed),
-accumulator(new (AllocCpc().allocate(1)) cpc_sketch_alloc<A>(lg_k, seed)),
+accumulator(nullptr),
 bit_matrix()
 {
   if (lg_k < CPC_MIN_LG_K || lg_k > CPC_MAX_LG_K) {
     throw std::invalid_argument("lg_k must be >= " + std::to_string(CPC_MIN_LG_K) + " and <= " + std::to_string(CPC_MAX_LG_K) + ": " + std::to_string(lg_k));
   }
+  accumulator = new (AllocCpc().allocate(1)) cpc_sketch_alloc<A>(lg_k, seed);
 }
 
 template<typename A>

--- a/cpc/test/cpc_sketch_test.cpp
+++ b/cpc/test/cpc_sketch_test.cpp
@@ -337,6 +337,7 @@ TEST_CASE("cpc sketch: serialize both ways", "[cpc_sketch]") {
   char* pp = new char[s.tellp()];
   s.read(pp, s.tellp());
   REQUIRE(std::memcmp(pp, bytes.data() + header_size_bytes, bytes.size() - header_size_bytes) == 0);
+  delete [] pp;
 }
 
 TEST_CASE("cpc sketch: update int equivalence", "[cpc_sketch]") {

--- a/fi/include/reverse_purge_hash_map_impl.hpp
+++ b/fi/include/reverse_purge_hash_map_impl.hpp
@@ -86,13 +86,18 @@ reverse_purge_hash_map<K, V, H, E, A>::~reverse_purge_hash_map() {
   const uint32_t size = 1 << lg_cur_size;
   if (num_active > 0) {
     for (uint32_t i = 0; i < size; i++) {
-      if (is_active(i)) keys[i].~K();
-      if (--num_active == 0) break;
+      if (is_active(i)) {
+        keys[i].~K();
+        if (--num_active == 0) break;
+      }
     }
   }
-  A().deallocate(keys, size);
-  AllocV().deallocate(values, size);
-  AllocU16().deallocate(states, size);
+  if (keys != nullptr)
+    A().deallocate(keys, size);
+  if (values != nullptr)
+    AllocV().deallocate(values, size);
+  if (states != nullptr)
+    AllocU16().deallocate(states, size);
 }
 
 template<typename K, typename V, typename H, typename E, typename A>

--- a/fi/test/frequent_items_sketch_test.cpp
+++ b/fi/test/frequent_items_sketch_test.cpp
@@ -31,6 +31,10 @@ static std::string testBinaryInputPath = "test/";
 
 namespace datasketches {
 
+TEST_CASE("frequent items: invalid k", "[frequent_items_sketch]") {
+  REQUIRE_THROWS_AS(frequent_items_sketch<int>(2), std::invalid_argument);
+}
+
 TEST_CASE("frequent items: empty", "[frequent_items_sketch]") {
   frequent_items_sketch<int> sketch(3);
   REQUIRE(sketch.is_empty());
@@ -277,7 +281,7 @@ TEST_CASE("frequent items: serialize deserialiation long64 bytes", "[frequent_it
   REQUIRE(sketch2.get_estimate(5) == 5);
 }
 
-TEST_CASE("frequent items: serialize deseriali string stream", "[frequent_items_sketch]") {
+TEST_CASE("frequent items: serialize deserialize string stream", "[frequent_items_sketch]") {
   frequent_items_sketch<std::string> sketch1(3);
   sketch1.update("aaaaaaaaaaaaaaaa", 1);
   sketch1.update("bbbbbbbbbbbbbbbb", 2);

--- a/hll/test/CouponListTest.cpp
+++ b/hll/test/CouponListTest.cpp
@@ -37,10 +37,10 @@ void println_string(std::string str) {
 TEST_CASE("coupon list: check iterator", "[coupon_list]") {
   int lgConfigK = 8;
   CouponList<> cl(lgConfigK, HLL_4, LIST);
-  for (int i = 1; i <= 8; ++i) { cl.couponUpdate(HllUtil<>::pair(i, i)); } // not hashes but distinct values
+  for (int i = 1; i <= 7; ++i) { cl.couponUpdate(HllUtil<>::pair(i, i)); } // not hashes but distinct values
   const int mask = (1 << lgConfigK) - 1;
   int idx = 0;
-  auto itr = cl.begin(true);
+  auto itr = cl.begin(false);
   while (itr != cl.end()) {
     int key = HllUtil<>::getLow26(*itr);
     int val = HllUtil<>::getValue(*itr);


### PR DESCRIPTION
i believe this gives us a clean bill of health from valgrind

the only remaining memory in use now should be the cpc tables, and that's very intentional.