### PR TITLE
Check buffer bounds

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -32,6 +32,7 @@ target_compile_features(common INTERFACE cxx_std_11)
 target_sources(common
   INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/common_defs.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/memory_operations.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/MurmurHash3.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/serde.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/count_zeros.hpp

--- a/common/include/memory_operations.hpp
+++ b/common/include/memory_operations.hpp
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _MEMORY_CHECKS_HPP_
+#define _MEMORY_CHECKS_HPP_
+
+#include <memory>
+#include <exception>
+#include <iostream>
+
+namespace datasketches {
+
+static inline void ensure_minimum_memory(size_t bytes_available, size_t min_needed) {
+  if (bytes_available < min_needed) {
+    throw std::out_of_range("Insufficient buffer size detected: bytes available "
+    + std::to_string((int) bytes_available) + ", minimum needed " + std::to_string((int) min_needed));
+  }  
+}
+
+static inline void check_memory_size(size_t requested_index, size_t capacity) {
+  if (requested_index > capacity) {
+    throw std::out_of_range("Attempt to access memory beyond limits: requested index "
+    + std::to_string((int) requested_index) + ", capacity " + std::to_string((int) capacity));
+  }
+}
+
+// note: size is in bytes, not items
+static inline size_t copy_from_mem(const void* src, void* dst, size_t size) {
+  memcpy(dst, src, size);
+  return size;
+}
+
+// note: size is in bytes, not items
+static inline size_t copy_to_mem(const void* src, void* dst, size_t size) {
+  memcpy(dst, src, size);
+  return size;
+}
+
+} // namespace
+
+#endif // _MEMORY_CHECKS_HPP_

--- a/common/test/test_type.hpp
+++ b/common/test/test_type.hpp
@@ -88,7 +88,7 @@ struct test_type_serde {
       new (&items[i]) test_type(value);
     }
   }
-  size_t size_of_item(const test_type& item) {
+  size_t size_of_item(const test_type&) {
     return sizeof(int);
   }
 };

--- a/fi/include/frequent_items_sketch_impl.hpp
+++ b/fi/include/frequent_items_sketch_impl.hpp
@@ -24,6 +24,8 @@
 #include <cstring>
 #include <limits>
 
+#include "memory_operations.hpp"
+
 namespace datasketches {
 
 // clang++ seems to require this declaration for CMAKE_BUILD_TYPE='Debug"
@@ -209,6 +211,7 @@ vector_u8<A> frequent_items_sketch<T, W, H, E, S, A>::serialize(unsigned header_
   const size_t size = header_size_bytes + get_serialized_size_bytes();
   vector_u8<A> bytes(size);
   uint8_t* ptr = bytes.data() + header_size_bytes;
+  uint8_t* end_ptr = ptr + size;
 
   const uint8_t preamble_longs = is_empty() ? PREAMBLE_LONGS_EMPTY : PREAMBLE_LONGS_NONEMPTY;
   ptr += copy_to_mem(&preamble_longs, ptr, sizeof(uint8_t));
@@ -245,7 +248,8 @@ vector_u8<A> frequent_items_sketch<T, W, H, E, S, A>::serialize(unsigned header_
     }
     ptr += copy_to_mem(weights, ptr, sizeof(W) * num_items);
     AllocW().deallocate(weights, num_items);
-    ptr += S().serialize(ptr, items, num_items);
+    const size_t bytes_remaining = end_ptr - ptr;
+    ptr += S().serialize(ptr, bytes_remaining, items, num_items);
     for (unsigned i = 0; i < num_items; i++) items[i].~T();
     A().deallocate(items, num_items);
   }
@@ -308,7 +312,9 @@ frequent_items_sketch<T, W, H, E, S, A> frequent_items_sketch<T, W, H, E, S, A>:
 
 template<typename T, typename W, typename H, typename E, typename S, typename A>
 frequent_items_sketch<T, W, H, E, S, A> frequent_items_sketch<T, W, H, E, S, A>::deserialize(const void* bytes, size_t size) {
+  ensure_minimum_memory(size, 8);
   const char* ptr = static_cast<const char*>(bytes);
+  const char* base = static_cast<const char*>(bytes);
   uint8_t preamble_longs;
   ptr += copy_from_mem(ptr, &preamble_longs, sizeof(uint8_t));
   uint8_t serial_version;
@@ -330,6 +336,7 @@ frequent_items_sketch<T, W, H, E, S, A> frequent_items_sketch<T, W, H, E, S, A>:
   check_serial_version(serial_version);
   check_family_id(family_id);
   check_size(lg_cur_size, lg_max_size);
+  ensure_minimum_memory(size, 1 << preamble_longs);
 
   frequent_items_sketch<T, W, H, E, S, A> sketch(lg_max_size, lg_cur_size);
   if (!is_empty) {
@@ -345,9 +352,11 @@ frequent_items_sketch<T, W, H, E, S, A> frequent_items_sketch<T, W, H, E, S, A>:
     // batch deserialization with intermediate array of items and weights
     typedef typename std::allocator_traits<A>::template rebind_alloc<W> AllocW;
     W* weights = AllocW().allocate(num_items);
+    ensure_minimum_memory(size, ptr - base + (sizeof(W) * num_items));
     ptr += copy_from_mem(ptr, weights, sizeof(W) * num_items);
     T* items = A().allocate(num_items);
-    ptr += S().deserialize(ptr, items, num_items);
+    const size_t bytes_remaining = size - (ptr - base);
+    ptr += S().deserialize(ptr, bytes_remaining, items, num_items);
     for (uint32_t i = 0; i < num_items; i++) {
       sketch.update(std::move(items[i]), weights[i]);
       items[i].~T();
@@ -436,7 +445,7 @@ void frequent_items_sketch<T, W, H, E, S, A>::check_weight(WW weight) {
 // version for integral unsigned type - no-op
 template<typename T, typename W, typename H, typename E, typename S, typename A>
 template<typename WW, typename std::enable_if<std::is_integral<WW>::value && std::is_unsigned<WW>::value, int>::type>
-void frequent_items_sketch<T, W, H, E, S, A>::check_weight(WW weight) {}
+void frequent_items_sketch<T, W, H, E, S, A>::check_weight(WW) {}
 
 // version for floating point type
 template<typename T, typename W, typename H, typename E, typename S, typename A>

--- a/hll/include/CompositeInterpolationXTable-internal.hpp
+++ b/hll/include/CompositeInterpolationXTable-internal.hpp
@@ -36,7 +36,7 @@ static const int yStrides[] =
   {1, 2, 3, 5, 10, 20, 40, 80, 160, 320, 640, 1280, 2560, 5120, 10240, 20480, 40960, 81920};
 
 template<typename A>
-const int CompositeInterpolationXTable<A>::get_y_stride(const int logK) {
+int CompositeInterpolationXTable<A>::get_y_stride(const int logK) {
   if (logK < HllUtil<A>::MIN_LOG_K || logK > HllUtil<A>::MAX_LOG_K) {
     throw std::invalid_argument("logK must be in range [" + std::to_string(HllUtil<A>::MIN_LOG_K)
                                 + ", " + std::to_string(HllUtil<A>::MAX_LOG_K) + "]. Found: "
@@ -46,7 +46,7 @@ const int CompositeInterpolationXTable<A>::get_y_stride(const int logK) {
 }
 
 template<typename A>
-const int CompositeInterpolationXTable<A>::get_x_arr_length(const int logK) {
+int CompositeInterpolationXTable<A>::get_x_arr_length() {
   return numXArrValues;
 }
 
@@ -797,7 +797,7 @@ static const double xArr[18][numXArrValues] = {
 };
 
 template<typename A>
-const double* const CompositeInterpolationXTable<A>::get_x_arr(const int logK) {
+const double* CompositeInterpolationXTable<A>::get_x_arr(const int logK) {
   if (logK < HllUtil<A>::MIN_LOG_K || logK > HllUtil<A>::MAX_LOG_K) {
     throw std::invalid_argument("logK must be in range [" + std::to_string(HllUtil<A>::MIN_LOG_K)
                                 + ", " + std::to_string(HllUtil<A>::MAX_LOG_K) + "]. Found: "

--- a/hll/include/CompositeInterpolationXTable.hpp
+++ b/hll/include/CompositeInterpolationXTable.hpp
@@ -27,10 +27,10 @@ namespace datasketches {
 template<typename A = std::allocator<char>>
 class CompositeInterpolationXTable {
   public:
-    static const int get_y_stride(int logK);
+    static int get_y_stride(int logK);
 
-    static const double* const get_x_arr(int logK);
-    static const int get_x_arr_length(int logK);
+    static const double* get_x_arr(int logK);
+    static int get_x_arr_length();
 };
 
 }

--- a/hll/include/HllArray-internal.hpp
+++ b/hll/include/HllArray-internal.hpp
@@ -405,7 +405,7 @@ double HllArray<A>::getCompositeEstimate() const {
   const double rawEst = getHllRawEstimate(this->lgConfigK, kxq0 + kxq1);
 
   const double* xArr = CompositeInterpolationXTable<A>::get_x_arr(this->lgConfigK);
-  const int xArrLen = CompositeInterpolationXTable<A>::get_x_arr_length(this->lgConfigK);
+  const int xArrLen = CompositeInterpolationXTable<A>::get_x_arr_length();
   const double yStride = CompositeInterpolationXTable<A>::get_y_stride(this->lgConfigK);
 
   if (rawEst < xArr[0]) {

--- a/hll/include/HllUnion-internal.hpp
+++ b/hll/include/HllUnion-internal.hpp
@@ -163,26 +163,6 @@ void hll_union_alloc<A>::coupon_update(const int coupon) {
 }
 
 template<typename A>
-vector_u8<A> hll_union_alloc<A>::serialize_compact() const {
-  return gadget.serialize_compact();
-}
-
-template<typename A>
-vector_u8<A> hll_union_alloc<A>::serialize_updatable() const {
-  return gadget.serialize_updatable();
-}
-
-template<typename A>
-void hll_union_alloc<A>::serialize_compact(std::ostream& os) const {
-  return gadget.serialize_compact(os);
-}
-
-template<typename A>
-void hll_union_alloc<A>::serialize_updatable(std::ostream& os) const {
-  return gadget.serialize_updatable(os);
-}
-
-template<typename A>
 std::ostream& hll_union_alloc<A>::to_string(std::ostream& os, const bool summary,
                                   const bool detail, const bool aux_detail, const bool all) const {
   return gadget.to_string(os, summary, detail, aux_detail, all);

--- a/hll/include/HllUtil.hpp
+++ b/hll/include/HllUtil.hpp
@@ -155,7 +155,7 @@ inline int HllUtil<A>::coupon(const HashState& hashState) {
 
 template<typename A>
 inline void HllUtil<A>::hash(const void* key, const int keyLen, const uint64_t seed, HashState& result) {
-  MurmurHash3_x64_128(key, keyLen, DEFAULT_SEED, result);
+  MurmurHash3_x64_128(key, keyLen, seed, result);
 }
 
 template<typename A>

--- a/hll/include/hll.hpp
+++ b/hll/include/hll.hpp
@@ -547,39 +547,10 @@ class hll_union_alloc {
      */
     hll_sketch_alloc<A> get_result(target_hll_type tgt_type = HLL_4) const;
 
-    typedef vector_u8<A> vector_bytes; // alias for users
-
-    /**
-     * Serializes the sketch to a byte array, compacting data structures
-     * where feasible to eliminate unused storage in the serialized image.
-     * @param header_size_bytes Allows for PostgreSQL integration
-     */
-    vector_bytes serialize_compact() const;
-  
-    /**
-     * Serializes the sketch to a byte array, retaining all internal 
-     * data structures in their current form.
-     */
-    vector_bytes serialize_updatable() const;
-
-    /**
-     * Serializes the sketch to an ostream, compacting data structures
-     * where feasible to eliminate unused storage in the serialized image.
-     * @param os std::ostream to use for output.
-     */
-    void serialize_compact(std::ostream& os) const;
-
-    /**
-     * Serializes the sketch to an ostream, retaining all internal data
-     * structures in their current form.
-     * @param os std::ostream to use for output.
-     */
-    void serialize_updatable(std::ostream& os) const;
-
     /**
      * Human readable summary with optional detail
      * @param os std::ostram to which the summary is written
-     * @param summary if true, output the sketch summary
+     * @param summary if true, output the union summary
      * @param detail if true, output the internal data array
      * @param auxDetail if true, output the internal Aux array, if it exists.
      * @param all if true, outputs all entries including empty ones

--- a/python/src/hll_wrapper.cpp
+++ b/python/src/hll_wrapper.cpp
@@ -41,21 +41,6 @@ py::object hll_sketch_serialize_updatable(const hll_sketch& sk) {
   return py::bytes((char*)serResult.data(), serResult.size());
 }
 
-hll_union hll_union_deserialize(py::bytes uBytes) {
-  std::string uStr = uBytes; // implicit cast
-  return hll_union::deserialize(uStr.c_str(), uStr.length());
-}
-
-py::object hll_union_serialize_compact(const hll_union& u) {
-  auto serResult = u.serialize_compact();
-  return py::bytes((char*)serResult.data(), serResult.size());
-}
-
-py::object hll_union_serialize_updatable(const hll_union& u) {
-  auto serResult = u.serialize_updatable();
-  return py::bytes((char*)serResult.data(), serResult.size());
-}
-
 }
 }
 
@@ -102,9 +87,6 @@ void init_hll(py::module &m) {
 
   py::class_<hll_union>(m, "hll_union")
     .def(py::init<int>(), py::arg("lg_max_k"))
-    .def_static("deserialize", &dspy::hll_union_deserialize)
-    .def("serialize_compact", &dspy::hll_union_serialize_compact)
-    .def("serialize_updatable", &dspy::hll_union_serialize_updatable)
     .def("to_string", (std::string (hll_union::*)(bool,bool,bool,bool) const) &hll_union::to_string,
          py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
     .def("__str__", (std::string (hll_union::*)(bool,bool,bool,bool) const) &hll_union::to_string,

--- a/python/tests/hll_test.py
+++ b/python/tests/hll_test.py
@@ -119,15 +119,6 @@ class HllTest(unittest.TestCase):
         sk = union.get_result()
         self.assertTrue(isinstance(sk, hll_sketch))
         self.assertEqual(sk.tgt_type, tgt_hll_type.HLL_4)
-
-        bytes_compact = union.serialize_compact()
-        bytes_update = union.serialize_updatable()
-        self.assertEqual(len(bytes_compact), union.get_compact_serialization_bytes())
-        self.assertEqual(len(bytes_update), union.get_updatable_serialization_bytes())
-
-        self.assertTrue(isinstance(hll_union.deserialize(bytes_compact), hll_union))
-        self.assertTrue(isinstance(hll_union.deserialize(bytes_update), hll_union))
-
         
     def generate_sketch(self, n, k, sk_type=tgt_hll_type.HLL_4, st_idx=0):
         sk = hll_sketch(k, sk_type)

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -144,7 +144,7 @@ class var_opt_sketch {
     // purpose is storing the state of the unioning algorithm) but for reasons of programming
     // convenience we are currently declaring them here. However, that could change in the future.
 
-    // Following int is:
+    // Following value is:
     //  1. Zero (for a varopt sketch)
     //  2. Count of marked items in H region, if part of a unioning algo's gadget
     uint32_t num_marks_in_h_;
@@ -172,24 +172,24 @@ class var_opt_sketch {
 
     inline double get_tau() const;
     inline double peek_min() const;
-    inline bool is_marked(int idx) const;
+    inline bool is_marked(uint32_t idx) const;
     
     inline uint32_t pick_random_slot_in_r() const;
-    inline uint32_t choose_delete_slot(double wt_cand, int num_cand) const;
-    inline uint32_t choose_weighted_delete_slot(double wt_cand, int num_cand) const;
+    inline uint32_t choose_delete_slot(double wt_cand, uint32_t num_cand) const;
+    inline uint32_t choose_weighted_delete_slot(double wt_cand, uint32_t num_cand) const;
 
     inline void transition_from_warmup();
     inline void convert_to_heap();
-    inline void restore_towards_leaves(int slot_in);
-    inline void restore_towards_root(int slot_in);
+    inline void restore_towards_leaves(uint32_t slot_in);
+    inline void restore_towards_root(uint32_t slot_in);
     inline void push(const T& item, double wt, bool mark);
     inline void pop_min_to_m_region();
-    void grow_candidate_set(double wt_cands, int num_cands);    
+    void grow_candidate_set(double wt_cands, uint32_t num_cands);    
     void decrease_k_by_1();
     void strip_marks();
-    void force_set_k(int k); // used to resolve union gadget into sketch
-    void downsample_candidate_set(double wt_cands, int num_cands);
-    inline void swap_values(int src, int dst);
+    void force_set_k(uint32_t k); // used to resolve union gadget into sketch
+    void downsample_candidate_set(double wt_cands, uint32_t num_cands);
+    inline void swap_values(uint32_t src, uint32_t dst);
     void grow_data_arrays();
     void allocate_data_arrays(uint32_t tgt_size, bool use_marks);
 
@@ -197,11 +197,11 @@ class var_opt_sketch {
     static void check_preamble_longs(uint8_t preamble_longs, uint8_t flags);
     static void check_family_and_serialization_version(uint8_t family_id, uint8_t ser_ver);
     // next method sets current_items_alloc_
-    void validate_and_set_current_size(int preamble_longs);
+    void validate_and_set_current_size(uint32_t preamble_longs);
 
     // things to move to common and be shared among sketches
-    static uint32_t get_adjusted_size(int max_size, int resize_target);
-    static uint32_t starting_sub_multiple(int lg_target, int lg_rf, int lg_min);
+    static uint32_t get_adjusted_size(uint32_t max_size, uint32_t resize_target);
+    static uint32_t starting_sub_multiple(uint32_t lg_target, uint32_t lg_rf, uint32_t lg_min);
     static inline double pseudo_hypergeometric_ub_on_p(uint64_t n, uint32_t k, double sampling_rate);
     static inline double pseudo_hypergeometric_lb_on_p(uint64_t n, uint32_t k, double sampling_rate);
     static bool is_power_of_2(uint32_t v);
@@ -232,7 +232,7 @@ private:
   // to R region (can correct for numerical precision issues)
   const_iterator(const var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region, bool weight_corr);
 
-  const bool get_mark() const;
+  bool get_mark() const;
 
   const var_opt_sketch<T,S,A>* sk_;
   double cum_r_weight_; // used for weight correction

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -144,7 +144,7 @@ class var_opt_sketch {
     // purpose is storing the state of the unioning algorithm) but for reasons of programming
     // convenience we are currently declaring them here. However, that could change in the future.
 
-    // Following value is:
+    // Following int is:
     //  1. Zero (for a varopt sketch)
     //  2. Count of marked items in H region, if part of a unioning algo's gadget
     uint32_t num_marks_in_h_;
@@ -172,24 +172,24 @@ class var_opt_sketch {
 
     inline double get_tau() const;
     inline double peek_min() const;
-    inline bool is_marked(uint32_t idx) const;
+    inline bool is_marked(int idx) const;
     
     inline uint32_t pick_random_slot_in_r() const;
-    inline uint32_t choose_delete_slot(double wt_cand, uint32_t num_cand) const;
-    inline uint32_t choose_weighted_delete_slot(double wt_cand, uint32_t num_cand) const;
+    inline uint32_t choose_delete_slot(double wt_cand, int num_cand) const;
+    inline uint32_t choose_weighted_delete_slot(double wt_cand, int num_cand) const;
 
     inline void transition_from_warmup();
     inline void convert_to_heap();
-    inline void restore_towards_leaves(uint32_t slot_in);
-    inline void restore_towards_root(uint32_t slot_in);
+    inline void restore_towards_leaves(int slot_in);
+    inline void restore_towards_root(int slot_in);
     inline void push(const T& item, double wt, bool mark);
     inline void pop_min_to_m_region();
-    void grow_candidate_set(double wt_cands, uint32_t num_cands);    
+    void grow_candidate_set(double wt_cands, int num_cands);    
     void decrease_k_by_1();
     void strip_marks();
-    void force_set_k(uint32_t k); // used to resolve union gadget into sketch
-    void downsample_candidate_set(double wt_cands, uint32_t num_cands);
-    inline void swap_values(uint32_t src, uint32_t dst);
+    void force_set_k(int k); // used to resolve union gadget into sketch
+    void downsample_candidate_set(double wt_cands, int num_cands);
+    inline void swap_values(int src, int dst);
     void grow_data_arrays();
     void allocate_data_arrays(uint32_t tgt_size, bool use_marks);
 
@@ -197,11 +197,11 @@ class var_opt_sketch {
     static void check_preamble_longs(uint8_t preamble_longs, uint8_t flags);
     static void check_family_and_serialization_version(uint8_t family_id, uint8_t ser_ver);
     // next method sets current_items_alloc_
-    void validate_and_set_current_size(uint32_t preamble_longs);
+    void validate_and_set_current_size(int preamble_longs);
 
     // things to move to common and be shared among sketches
-    static uint32_t get_adjusted_size(uint32_t max_size, uint32_t resize_target);
-    static uint32_t starting_sub_multiple(uint32_t lg_target, uint32_t lg_rf, uint32_t lg_min);
+    static uint32_t get_adjusted_size(int max_size, int resize_target);
+    static uint32_t starting_sub_multiple(int lg_target, int lg_rf, int lg_min);
     static inline double pseudo_hypergeometric_ub_on_p(uint64_t n, uint32_t k, double sampling_rate);
     static inline double pseudo_hypergeometric_lb_on_p(uint64_t n, uint32_t k, double sampling_rate);
     static bool is_power_of_2(uint32_t v);

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -363,7 +363,7 @@ var_opt_sketch<T,S,A>::var_opt_sketch(uint32_t k, resize_factor rf, bool is_gadg
 
   // read the sample items, skipping the gap. Either h_ or r_ may be 0
   size_t bytes_remaining = end_ptr - ptr;
-  ptr += S().deserialize(ptr, bytes_remaining, data_, h_); // ala data_[0]
+  ptr += S().deserialize(ptr, bytes_remaining, data_, h_);
   bytes_remaining = end_ptr - ptr;
   ptr += S().deserialize(ptr, bytes_remaining, &data_[h_ + 1], r_);
 }

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -29,6 +29,7 @@
 
 #include "var_opt_sketch.hpp"
 #include "serde.hpp"
+#include "memory_operations.hpp"
 #include "bounds_binomial_proportions.hpp"
 #include "count_zeros.hpp"
 
@@ -169,7 +170,7 @@ var_opt_sketch<T,S,A>::var_opt_sketch(uint32_t k, resize_factor rf, bool is_gadg
   }
 
   uint32_t ceiling_lg_k = to_log_2(ceiling_power_of_2(k_));
-  int initial_lg_size = starting_sub_multiple(ceiling_lg_k, rf_, MIN_LG_ARR_ITEMS);
+  uint32_t initial_lg_size = starting_sub_multiple(ceiling_lg_k, rf_, MIN_LG_ARR_ITEMS);
   curr_items_alloc_ = get_adjusted_size(k_, 1 << initial_lg_size);
   if (curr_items_alloc_ == k_) { // if full size, need to leave 1 for the gap
     ++curr_items_alloc_;
@@ -306,6 +307,9 @@ template<typename T, typename S, typename A>
 var_opt_sketch<T,S,A>::var_opt_sketch(uint32_t k, resize_factor rf, bool is_gadget, uint8_t preamble_longs,
                                       const void* bytes, size_t size) : k_(k), m_(0), rf_(rf) {
   // private constructor so we assume not called if sketch is empty
+  // and already checked that the array can hold the preamble
+  const char* base = static_cast<const char*>(bytes);
+  const char* end_ptr = base + size;
   const char* ptr = static_cast<const char*>(bytes) + sizeof(uint64_t);
 
   // second and third prelongs
@@ -329,6 +333,7 @@ var_opt_sketch<T,S,A>::var_opt_sketch(uint32_t k, resize_factor rf, bool is_gadg
   allocate_data_arrays(curr_items_alloc_, is_gadget);
 
   // read the first h_ weights, fill in rest of array with -1.0
+  check_memory_size(ptr - base + (h_ * sizeof(double)), size);
   ptr += copy_from_mem(ptr, weights_, h_ * sizeof(double));
   for (size_t i = 0; i < h_; ++i) {
     if (!(weights_[i] > 0.0)) {
@@ -345,6 +350,8 @@ var_opt_sketch<T,S,A>::var_opt_sketch(uint32_t k, resize_factor rf, bool is_gadg
   num_marks_in_h_ = 0;
   if (is_gadget) {
     uint8_t val = 0;
+    const size_t size_marks = h_ / 8 + (h_ % 8 > 0 ? 1 : 0);
+    check_memory_size(ptr - base + size_marks, size);
     for (uint32_t i = 0; i < h_; ++i) {
      if ((i & 0x7) == 0x0) { // should trigger on first iteration
         ptr += copy_from_mem(ptr, &val, sizeof(val));
@@ -355,8 +362,10 @@ var_opt_sketch<T,S,A>::var_opt_sketch(uint32_t k, resize_factor rf, bool is_gadg
   }
 
   // read the sample items, skipping the gap. Either h_ or r_ may be 0
-  ptr += S().deserialize(ptr, data_, h_); // ala data_[0]
-  ptr += S().deserialize(ptr, &data_[h_ + 1], r_);
+  size_t bytes_remaining = end_ptr - ptr;
+  ptr += S().deserialize(ptr, bytes_remaining, data_, h_); // ala data_[0]
+  bytes_remaining = end_ptr - ptr;
+  ptr += S().deserialize(ptr, bytes_remaining, &data_[h_ + 1], r_);
 }
 
 /*
@@ -433,6 +442,7 @@ std::vector<uint8_t, AllocU8<A>> var_opt_sketch<T,S,A>::serialize(unsigned heade
   const size_t size = header_size_bytes + get_serialized_size_bytes();
   std::vector<uint8_t, AllocU8<A>> bytes(size);
   uint8_t* ptr = bytes.data() + header_size_bytes;
+  uint8_t* end_ptr = ptr + size;
 
   bool empty = is_empty();
   uint8_t preLongs = (empty ? PREAMBLE_LONGS_EMPTY
@@ -488,11 +498,13 @@ std::vector<uint8_t, AllocU8<A>> var_opt_sketch<T,S,A>::serialize(unsigned heade
     }
 
     // write the sample items, skipping the gap. Either h_ or r_ may be 0
-    ptr += S().serialize(ptr, data_, h_);
-    ptr += S().serialize(ptr, &data_[h_ + 1], r_);
+    size_t bytes_remaining = end_ptr - ptr;
+    ptr += S().serialize(ptr, bytes_remaining, data_, h_);
+    bytes_remaining = end_ptr - ptr;
+    ptr += S().serialize(ptr, bytes_remaining, &data_[h_ + 1], r_);
   }
   
-  size_t bytes_written = ptr - bytes.data();
+  size_t bytes_written = ptr - bytes.data() + header_size_bytes;
   if (bytes_written != size) {
     throw std::logic_error("serialized size mismatch: " + std::to_string(bytes_written) + " != " + std::to_string(size));
   }
@@ -564,6 +576,7 @@ void var_opt_sketch<T,S,A>::serialize(std::ostream& os) const {
 
 template<typename T, typename S, typename A>
 var_opt_sketch<T,S,A> var_opt_sketch<T,S,A>::deserialize(const void* bytes, size_t size) {
+  ensure_minimum_memory(size, 8);
   const char* ptr = static_cast<const char*>(bytes);
   uint8_t first_byte;
   ptr += copy_from_mem(ptr, &first_byte, sizeof(first_byte));
@@ -580,6 +593,7 @@ var_opt_sketch<T,S,A> var_opt_sketch<T,S,A>::deserialize(const void* bytes, size
 
   check_preamble_longs(preamble_longs, flags);
   check_family_and_serialization_version(family_id, serial_version);
+  ensure_minimum_memory(size, (size_t) (preamble_longs << 3));
 
   const bool is_empty = flags & EMPTY_FLAG_MASK;
   const bool is_gadget = flags & GADGET_FLAG_MASK;
@@ -620,7 +634,7 @@ template<typename T, typename S, typename A>
 void var_opt_sketch<T,S,A>::reset() {
   const uint32_t prev_alloc = curr_items_alloc_;
   const uint32_t ceiling_lg_k = to_log_2(ceiling_power_of_2(k_));
-  const int initial_lg_size = starting_sub_multiple(ceiling_lg_k, rf_, MIN_LG_ARR_ITEMS);
+  const uint32_t initial_lg_size = starting_sub_multiple(ceiling_lg_k, rf_, MIN_LG_ARR_ITEMS);
   curr_items_alloc_ = get_adjusted_size(k_, 1 << initial_lg_size);
   if (curr_items_alloc_ == k_) { // if full size, need to leave 1 for the gap
     ++curr_items_alloc_;
@@ -789,7 +803,7 @@ void var_opt_sketch<T,S,A>::update_warmup_phase(const T& item, double weight, bo
 
   // check if need to heapify
   if (h_ > k_) {
-    filled_data_ = true;
+    if (h_ == curr_items_alloc_) { filled_data_ = true; }
     transition_from_warmup();
   }
 }
@@ -803,7 +817,7 @@ void var_opt_sketch<T,S,A>::update_light(const T& item, double weight, bool mark
   assert(r_ >= 1);
   assert((r_ + h_) == k_);
 
-  const int m_slot = h_; // index of the gap, which becomes the M region
+  const uint32_t m_slot = h_; // index of the gap, which becomes the M region
   if (filled_data_) {
     data_[m_slot] = item;
   } else {
@@ -851,7 +865,7 @@ void var_opt_sketch<T,S,A>::update_heavy_r_eq1(const T& item, double weight, boo
 
   // Any set of two items is downsample-able to one item,
   // so the two lightest items are a valid starting point for the following
-  const int m_slot = k_ - 1; // array is k+1, 1 in R, so slot before is M
+  const uint32_t m_slot = k_ - 1; // array is k+1, 1 in R, so slot before is M
   grow_candidate_set(weights_[m_slot] + total_wt_r_, 2);
 }
 
@@ -1000,31 +1014,31 @@ void var_opt_sketch<T,S,A>::convert_to_heap() {
     return; // nothing to do
   }
 
-  const int last_slot = h_ - 1;
-  const int last_non_leaf = ((last_slot + 1) / 2) - 1;
+  const uint32_t last_slot = h_ - 1;
+  const uint32_t last_non_leaf = ((last_slot + 1) / 2) - 1;
   
   for (int j = last_non_leaf; j >= 0; --j) {
-    restore_towards_leaves(j);
+    restore_towards_leaves(static_cast<uint32_t>(j));
   }
 
   // validates heap, used for initial debugging
-  //for (int j = h_ - 1; j >= 1; --j) {
+  //for (uint32_t j = h_ - 1; j > 0; --j) {
   //  int p = ((j + 1) / 2) - 1;
   //  assert(weights_[p] <= weights_[j]);
   //}
 }
 
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::restore_towards_leaves(int slot_in) {
+void var_opt_sketch<T,S,A>::restore_towards_leaves(uint32_t slot_in) {
   assert(h_ > 0);
-  const int last_slot = h_ - 1;
+  const uint32_t last_slot = h_ - 1;
   assert(slot_in <= last_slot);
 
-  int slot = slot_in;
-  int child = (2 * slot_in) + 1; // might be invalid, need to check
+  uint32_t slot = slot_in;
+  uint32_t child = (2 * slot_in) + 1; // might be invalid, need to check
 
   while (child <= last_slot) {
-    int child2 = child + 1; // might also be invalid
+    uint32_t child2 = child + 1; // might also be invalid
     if ((child2 <= last_slot) && (weights_[child2] < weights_[child])) {
       // siwtch to other child if it's both valid and smaller
       child = child2;
@@ -1044,9 +1058,9 @@ void var_opt_sketch<T,S,A>::restore_towards_leaves(int slot_in) {
 }
 
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::restore_towards_root(int slot_in) {
-  int slot = slot_in;
-  int p = (((slot + 1) / 2) - 1); // valid if slot >= 1
+void var_opt_sketch<T,S,A>::restore_towards_root(uint32_t slot_in) {
+  uint32_t slot = slot_in;
+  uint32_t p = (((slot + 1) / 2) - 1); // valid if slot >= 1
   while ((slot > 0) && (weights_[slot] < weights_[p])) {
     swap_values(slot, p);
     slot = p;
@@ -1083,7 +1097,7 @@ void var_opt_sketch<T,S,A>::pop_min_to_m_region() {
     --h_;
   } else {
     // main case
-    int tgt = h_ - 1; // last slot, will swap with root
+    uint32_t tgt = h_ - 1; // last slot, will swap with root
     swap_values(0, tgt);
     ++m_;
     --h_;
@@ -1098,7 +1112,7 @@ void var_opt_sketch<T,S,A>::pop_min_to_m_region() {
 
 
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::swap_values(int src, int dst) {
+void var_opt_sketch<T,S,A>::swap_values(uint32_t src, uint32_t dst) {
   std::swap(data_[src], data_[dst]);
   std::swap(weights_[src], weights_[dst]);
 
@@ -1116,7 +1130,7 @@ void var_opt_sketch<T,S,A>::swap_values(int src, int dst) {
    by pulling sufficiently light items from h to m.
 */
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::grow_candidate_set(double wt_cands, int num_cands) {
+void var_opt_sketch<T,S,A>::grow_candidate_set(double wt_cands, uint32_t num_cands) {
   assert(h_ + m_ + r_ == k_ + 1);
   assert(num_cands >= 2);
   assert(num_cands == m_ + r_);
@@ -1142,21 +1156,21 @@ void var_opt_sketch<T,S,A>::grow_candidate_set(double wt_cands, int num_cands) {
 }
 
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::downsample_candidate_set(double wt_cands, int num_cands) {
+void var_opt_sketch<T,S,A>::downsample_candidate_set(double wt_cands, uint32_t num_cands) {
   assert(num_cands >= 2);
   assert(h_ + num_cands == k_ + 1);
 
   // need this before overwriting anything
-  const int delete_slot = choose_delete_slot(wt_cands, num_cands);
-  const int leftmost_cand_slot = h_;
+  const uint32_t delete_slot = choose_delete_slot(wt_cands, num_cands);
+  const uint32_t leftmost_cand_slot = h_;
   assert(delete_slot >= leftmost_cand_slot);
   assert(delete_slot <= k_);
 
   // Overwrite weights for items from M moving into R,
   // to make bugs more obvious. Also needed so anyone reading the
   // weight knows if it's invalid without checking h_ and m_
-  const int stop_idx = leftmost_cand_slot + m_;
-  for (int j = leftmost_cand_slot; j < stop_idx; ++j) {
+  const uint32_t stop_idx = leftmost_cand_slot + m_;
+  for (uint32_t j = leftmost_cand_slot; j < stop_idx; ++j) {
     weights_[j] = -1.0;
   }
 
@@ -1170,7 +1184,7 @@ void var_opt_sketch<T,S,A>::downsample_candidate_set(double wt_cands, int num_ca
 }
 
 template<typename T, typename S, typename A>
-uint32_t var_opt_sketch<T,S,A>::choose_delete_slot(double wt_cands, int num_cands) const {
+uint32_t var_opt_sketch<T,S,A>::choose_delete_slot(double wt_cands, uint32_t num_cands) const {
   assert(r_ > 0);
 
   if (m_ == 0) {
@@ -1187,8 +1201,8 @@ uint32_t var_opt_sketch<T,S,A>::choose_delete_slot(double wt_cands, int num_cand
     }
   } else {
     // general case
-    const int delete_slot = choose_weighted_delete_slot(wt_cands, num_cands);
-    const int first_r_slot = h_ + m_;
+    const uint32_t delete_slot = choose_weighted_delete_slot(wt_cands, num_cands);
+    const uint32_t first_r_slot = h_ + m_;
     if (delete_slot == first_r_slot) {
       return pick_random_slot_in_r();
     } else {
@@ -1198,17 +1212,17 @@ uint32_t var_opt_sketch<T,S,A>::choose_delete_slot(double wt_cands, int num_cand
 }
 
 template<typename T, typename S, typename A>
-uint32_t var_opt_sketch<T,S,A>::choose_weighted_delete_slot(double wt_cands, int num_cands) const {
+uint32_t var_opt_sketch<T,S,A>::choose_weighted_delete_slot(double wt_cands, uint32_t num_cands) const {
   assert(m_ >= 1);
 
-  const int offset = h_;
-  const int final_m = (offset + m_) - 1;
-  const int num_to_keep = num_cands - 1;
+  const uint32_t offset = h_;
+  const uint32_t final_m = (offset + m_) - 1;
+  const uint32_t num_to_keep = num_cands - 1;
 
   double left_subtotal = 0.0;
   double right_subtotal = -1.0 * wt_cands * next_double_exclude_zero();
 
-  for (int i = offset; i <= final_m; ++i) {
+  for (uint32_t i = offset; i <= final_m; ++i) {
     left_subtotal += num_to_keep * weights_[i];
     right_subtotal += wt_cands;
 
@@ -1224,7 +1238,7 @@ uint32_t var_opt_sketch<T,S,A>::choose_weighted_delete_slot(double wt_cands, int
 template<typename T, typename S, typename A>
 uint32_t var_opt_sketch<T,S,A>::pick_random_slot_in_r() const {
   assert(r_ > 0);
-  const int offset = h_ + m_;
+  const uint32_t offset = h_ + m_;
   if (r_ == 1) {
     return offset;
   } else {
@@ -1239,7 +1253,7 @@ double var_opt_sketch<T,S,A>::peek_min() const {
 }
 
 template<typename T, typename S, typename A>
-inline bool var_opt_sketch<T,S,A>::is_marked(int idx) const {
+inline bool var_opt_sketch<T,S,A>::is_marked(uint32_t idx) const {
   return marks_ == nullptr ? false : marks_[idx];
 }
 
@@ -1293,7 +1307,7 @@ void var_opt_sketch<T,S,A>::check_family_and_serialization_version(uint8_t famil
 }
 
 template<typename T, typename S, typename A>
-void var_opt_sketch<T, S, A>::validate_and_set_current_size(int preamble_longs) {
+void var_opt_sketch<T, S, A>::validate_and_set_current_size(uint32_t preamble_longs) {
   if (k_ == 0 || k_ > MAX_K) {
     throw std::invalid_argument("k must be at least 1 and less than 2^31 - 1");
   }
@@ -1314,7 +1328,7 @@ void var_opt_sketch<T, S, A>::validate_and_set_current_size(int preamble_longs) 
 
     const uint32_t ceiling_lg_k = to_log_2(ceiling_power_of_2(k_));
     const uint32_t min_lg_size = to_log_2(ceiling_power_of_2(h_));
-    const int initial_lg_size = starting_sub_multiple(ceiling_lg_k, rf_, min_lg_size);
+    const uint32_t initial_lg_size = starting_sub_multiple(ceiling_lg_k, rf_, min_lg_size);
     curr_items_alloc_ = get_adjusted_size(k_, 1 << initial_lg_size);
     if (curr_items_alloc_ == k_) { // if full size, need to leave 1 for the gap
       ++curr_items_alloc_;
@@ -1491,7 +1505,7 @@ const std::pair<const T&, const double> var_opt_sketch<T, S, A>::const_iterator:
 }
 
 template<typename T, typename S, typename A>
-const bool var_opt_sketch<T, S, A>::const_iterator::get_mark() const {
+bool var_opt_sketch<T, S, A>::const_iterator::get_mark() const {
   return sk_->marks_ == nullptr ? false : sk_->marks_[idx_];
 }
 
@@ -1509,15 +1523,15 @@ namespace random_utils {
  * If so, returns max sampling size, otherwise passes through target size.
  */
 template<typename T, typename S, typename A>
-uint32_t var_opt_sketch<T,S,A>::get_adjusted_size(int max_size, int resize_target) {
-  if (max_size - (resize_target << 1) < 0L) {
+uint32_t var_opt_sketch<T,S,A>::get_adjusted_size(uint32_t max_size, uint32_t resize_target) {
+  if (static_cast<int32_t>(max_size) - (resize_target << 1) < 0L) {
     return max_size;
   }
   return resize_target;
 }
 
 template<typename T, typename S, typename A>
-uint32_t var_opt_sketch<T,S,A>::starting_sub_multiple(int lg_target, int lg_rf, int lg_min) {
+uint32_t var_opt_sketch<T,S,A>::starting_sub_multiple(uint32_t lg_target, uint32_t lg_rf, uint32_t lg_min) {
   return (lg_target <= lg_min)
           ? lg_min : (lg_rf == 0) ? lg_target
           : (lg_target - lg_min) % lg_rf + lg_min;

--- a/sampling/include/var_opt_union_impl.hpp
+++ b/sampling/include/var_opt_union_impl.hpp
@@ -20,10 +20,11 @@
 #ifndef _VAR_OPT_UNION_IMPL_HPP_
 #define _VAR_OPT_UNION_IMPL_HPP_
 
-#include "var_opt_union.hpp"
-
 #include <cmath>
 #include <sstream>
+
+#include "var_opt_union.hpp"
+#include "memory_operations.hpp"
 
 namespace datasketches {
 
@@ -167,6 +168,7 @@ var_opt_union<T,S,A> var_opt_union<T,S,A>::deserialize(std::istream& is) {
 
 template<typename T, typename S, typename A>
 var_opt_union<T,S,A> var_opt_union<T,S,A>::deserialize(const void* bytes, size_t size) {
+  ensure_minimum_memory(size, 8);
   const char* ptr = static_cast<const char*>(bytes);
   uint8_t preamble_longs;
   ptr += copy_from_mem(ptr, &preamble_longs, sizeof(preamble_longs));
@@ -181,6 +183,7 @@ var_opt_union<T,S,A> var_opt_union<T,S,A>::deserialize(const void* bytes, size_t
 
   check_preamble_longs(preamble_longs, flags);
   check_family_and_serialization_version(family_id, serial_version);
+  ensure_minimum_memory(size, (size_t) (preamble_longs << 3));
 
   if (max_k == 0 || max_k > MAX_K) {
     throw std::invalid_argument("k must be at least 1 and less than 2^31 - 1");

--- a/sampling/include/var_opt_union_impl.hpp
+++ b/sampling/include/var_opt_union_impl.hpp
@@ -20,11 +20,10 @@
 #ifndef _VAR_OPT_UNION_IMPL_HPP_
 #define _VAR_OPT_UNION_IMPL_HPP_
 
+#include "var_opt_union.hpp"
+
 #include <cmath>
 #include <sstream>
-
-#include "var_opt_union.hpp"
-#include "memory_operations.hpp"
 
 namespace datasketches {
 
@@ -168,7 +167,6 @@ var_opt_union<T,S,A> var_opt_union<T,S,A>::deserialize(std::istream& is) {
 
 template<typename T, typename S, typename A>
 var_opt_union<T,S,A> var_opt_union<T,S,A>::deserialize(const void* bytes, size_t size) {
-  ensure_minimum_memory(size, 8);
   const char* ptr = static_cast<const char*>(bytes);
   uint8_t preamble_longs;
   ptr += copy_from_mem(ptr, &preamble_longs, sizeof(preamble_longs));
@@ -183,7 +181,6 @@ var_opt_union<T,S,A> var_opt_union<T,S,A>::deserialize(const void* bytes, size_t
 
   check_preamble_longs(preamble_longs, flags);
   check_family_and_serialization_version(family_id, serial_version);
-  ensure_minimum_memory(size, (size_t) (preamble_longs << 3));
 
   if (max_k == 0 || max_k > MAX_K) {
     throw std::invalid_argument("k must be at least 1 and less than 2^31 - 1");

--- a/sampling/test/var_opt_sketch_test.cpp
+++ b/sampling/test/var_opt_sketch_test.cpp
@@ -454,7 +454,7 @@ TEST_CASE("varopt sketch: deserialize exact from java", "[var_opt_sketch]") {
   REQUIRE(sketch.get_k() == 1024);
   REQUIRE(sketch.get_n() == 200);
   REQUIRE(sketch.get_num_samples() == 200);
-  subset_summary ss = sketch.estimate_subset_sum([](std::string x){ return true; });
+  subset_summary ss = sketch.estimate_subset_sum([](std::string){ return true; });
 
   double tgt_wt = 0.0;
   for (int i = 1; i <= 200; ++i) { tgt_wt += 1000.0 / i; }
@@ -471,7 +471,7 @@ TEST_CASE("varopt sketch: deserialize sampling from java", "[var_opt_sketch]") {
   REQUIRE(sketch.get_k() == 1024);
   REQUIRE(sketch.get_n() == 2003);
   REQUIRE(sketch.get_num_samples() == sketch.get_k());
-  subset_summary ss = sketch.estimate_subset_sum([](int64_t x){ return true; });
+  subset_summary ss = sketch.estimate_subset_sum([](int64_t){ return true; });
   REQUIRE(ss.estimate == Approx(332000.0).margin(EPS));
   REQUIRE(ss.total_sketch_weight == Approx(332000.0).margin(EPS));
 

--- a/sampling/test/var_opt_union_test.cpp
+++ b/sampling/test/var_opt_union_test.cpp
@@ -211,7 +211,7 @@ TEST_CASE("varopt union: identical sampling sketches", "[var_opt_union]") {
 
   var_opt_sketch<int> result = u.get_result();
   double expected_wt = 2.0 * n;
-  subset_summary ss = result.estimate_subset_sum([](int x){return true;});
+  subset_summary ss = result.estimate_subset_sum([](int){return true;});
   REQUIRE(result.get_n() == 2 * n);
   REQUIRE(ss.total_sketch_weight == Approx(expected_wt).margin(EPS));
 
@@ -220,7 +220,7 @@ TEST_CASE("varopt union: identical sampling sketches", "[var_opt_union]") {
   u.update(sk);
   result = u.get_result();
   expected_wt = (2.0 * n) + k + 1;
-  ss = result.estimate_subset_sum([](int x){return true;});
+  ss = result.estimate_subset_sum([](int){return true;});
   REQUIRE(result.get_n() == (2 * n) + k + 1);
   REQUIRE(ss.total_sketch_weight == Approx(expected_wt).margin(EPS));
 }
@@ -292,7 +292,7 @@ TEST_CASE("varopt union: deserialize from java", "[var_opt_union]") {
   REQUIRE(result.get_n() == 97);
   
   double expected_wt = 96.0;// light items -- ignoring the heavy one
-  subset_summary ss = result.estimate_subset_sum([](float x){return x >= 0;});
+  subset_summary ss = result.estimate_subset_sum([](double x){return x >= 0;});
   REQUIRE(ss.estimate == Approx(expected_wt).margin(EPS));
   REQUIRE(ss.total_sketch_weight == Approx(expected_wt + 1024.0).margin(EPS));
   REQUIRE(result.get_k() < 128);

--- a/theta/include/theta_sketch.hpp
+++ b/theta/include/theta_sketch.hpp
@@ -191,7 +191,6 @@ protected:
   static void check_sketch_type(uint8_t actual, uint8_t expected);
   static void check_serial_version(uint8_t actual, uint8_t expected);
   static void check_seed_hash(uint16_t actual, uint16_t expected);
-  static void check_size(size_t actual, size_t expected);
 
   friend theta_intersection_alloc<A>;
   friend theta_a_not_b_alloc<A>;


### PR DESCRIPTION
- add memory_operations.hpp
- ensure we're checking bounds on deserialization for all sketch types
- ensure sketches that take arbitrary types can check bounds on serialize