### PR TITLE
kll: check for NaN on update with floating point types

### DIFF
--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -505,17 +505,28 @@ class kll_sketch {
     static void check_serial_version(uint8_t serial_version);
     static void check_family_id(uint8_t family_id);
 
-    // implementation for floating point types
+    // implementations for floating point types
     template<typename TT = T, typename std::enable_if<std::is_floating_point<TT>::value, int>::type = 0>
     static TT get_invalid_value() {
       return std::numeric_limits<TT>::quiet_NaN();
     }
 
-    // implementation for all other types
+    template<typename TT = T, typename std::enable_if<std::is_floating_point<TT>::value, int>::type = 0>
+    static inline bool check_update_value(TT value) {
+      return !std::isnan(value);
+    }
+
+    // implementations for all other types
     template<typename TT = T, typename std::enable_if<!std::is_floating_point<TT>::value, int>::type = 0>
     static TT get_invalid_value() {
       throw std::runtime_error("getting quantiles from empty sketch is not supported for this type of values");
     }
+
+    template<typename TT = T, typename std::enable_if<!std::is_floating_point<TT>::value, int>::type = 0>
+    static inline bool check_update_value(TT) {
+      return true;
+    }
+
 };
 
 template<typename T, typename C, typename S, typename A>

--- a/kll/include/kll_sketch_impl.hpp
+++ b/kll/include/kll_sketch_impl.hpp
@@ -141,6 +141,7 @@ kll_sketch<T, C, S, A>::~kll_sketch() {
 
 template<typename T, typename C, typename S, typename A>
 void kll_sketch<T, C, S, A>::update(const T& value) {
+  if (!check_update_value(value)) { return; }
   update_min_max(value);
   const uint32_t index = internal_update();
   new (&items_[index]) T(value);
@@ -148,6 +149,7 @@ void kll_sketch<T, C, S, A>::update(const T& value) {
 
 template<typename T, typename C, typename S, typename A>
 void kll_sketch<T, C, S, A>::update(T&& value) {
+  if (!check_update_value(value)) { return; }
   update_min_max(value);
   const uint32_t index = internal_update();
   new (&items_[index]) T(std::move(value));

--- a/kll/test/kll_sketch_test.cpp
+++ b/kll/test/kll_sketch_test.cpp
@@ -111,6 +111,16 @@ TEST_CASE("kll sketch", "[kll_sketch]") {
     REQUIRE(count == 1);
   }
 
+  SECTION("NaN") {
+    kll_float_sketch sketch;
+    sketch.update(std::numeric_limits<float>::quiet_NaN());
+    REQUIRE(sketch.is_empty());
+
+    sketch.update(0.0);
+    sketch.update(std::numeric_limits<float>::quiet_NaN());
+    REQUIRE(sketch.get_n() == 1);
+  }
+
   SECTION("many items, exact mode") {
     kll_float_sketch sketch;
     const uint32_t n(200);


### PR DESCRIPTION
Should fix #133 