### PR TITLE
To string

### DIFF
--- a/common/include/common_defs.hpp
+++ b/common/include/common_defs.hpp
@@ -21,10 +21,14 @@
 #define _COMMON_DEFS_HPP_
 
 #include <cstdint>
+#include <string>
 
 namespace datasketches {
 
 static const uint64_t DEFAULT_SEED = 9001;
+
+template<typename A> using AllocChar = typename std::allocator_traits<A>::template rebind_alloc<char>;
+template<typename A> using string = std::basic_string<char, std::char_traits<char>, AllocChar<A>>;
 
 } // namespace
 

--- a/common/include/common_defs.hpp
+++ b/common/include/common_defs.hpp
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <string>
+#include <memory>
 
 namespace datasketches {
 

--- a/cpc/include/cpc_sketch.hpp
+++ b/cpc/include/cpc_sketch.hpp
@@ -192,11 +192,9 @@ public:
   void update(const void* value, int size);
 
   /**
-   * Writes a human-readable summary of this sketch to a given stream
-   * @param os output stream
-   * @param print_items if true include the list of items retained by the sketch
+   * Returns a human-readable summary of this sketch
    */
-  void to_stream(std::ostream& os) const;
+  string<A> to_string() const;
 
   /**
    * This method serializes the sketch into a given stream in a binary form

--- a/cpc/include/cpc_sketch_impl.hpp
+++ b/cpc/include/cpc_sketch_impl.hpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <cmath>
 #include <cstring>
+#include <sstream>
 
 #include "cpc_confidence.hpp"
 #include "kxp_byte_lookup.hpp"
@@ -376,7 +377,8 @@ void cpc_sketch_alloc<A>::refresh_kxp(const uint64_t* bit_matrix) {
 }
 
 template<typename A>
-void cpc_sketch_alloc<A>::to_stream(std::ostream& os) const {
+string<A> cpc_sketch_alloc<A>::to_string() const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### CPC sketch summary:" << std::endl;
   os << "   lg_k           : " << std::to_string(lg_k) << std::endl;
   os << "   seed hash      : " << std::hex << compute_seed_hash(seed) << std::dec << std::endl;
@@ -394,6 +396,7 @@ void cpc_sketch_alloc<A>::to_stream(std::ostream& os) const {
     os << "   window offset  : " << std::to_string(window_offset) << std::endl;
   }
   os << "### End sketch summary" << std::endl;
+  return os.str();
 }
 
 template<typename A>

--- a/cpc/test/cpc_sketch_test.cpp
+++ b/cpc/test/cpc_sketch_test.cpp
@@ -72,7 +72,6 @@ TEST_CASE("cpc sketch: overflow bug", "[cpc_sketch]") {
   const int n = 100000000;
   uint64_t key = 15200000000; // problem happened with this sequence
   for (int i = 0; i < n; i++) sketch.update(key++);
-  //sketch.to_stream(std::cout);
   REQUIRE_FALSE(sketch.is_empty());
   REQUIRE(sketch.get_estimate() == Approx(n).margin(n * 0.1));
   REQUIRE(sketch.get_estimate() >= sketch.get_lower_bound(1));
@@ -97,11 +96,9 @@ TEST_CASE("cpc sketch: serialize deserialize sparse", "[cpc_sketch]") {
   cpc_sketch sketch(11);
   const int n(100);
   for (int i = 0; i < n; i++) sketch.update(i);
-  //sketch.to_stream(std::cerr);
   std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
   sketch.serialize(s);
   cpc_sketch deserialized = cpc_sketch::deserialize(s);
-  //deserialized.to_stream(std::cerr);
   REQUIRE(deserialized.is_empty() == sketch.is_empty());
   REQUIRE(deserialized.get_estimate() == sketch.get_estimate());
   REQUIRE(deserialized.validate());
@@ -119,11 +116,9 @@ TEST_CASE("cpc sketch: serialize deserialize hybrid", "[cpc_sketch]") {
   cpc_sketch sketch(11);
   const int n(200);
   for (int i = 0; i < n; i++) sketch.update(i);
-  //sketch.to_stream(std::cerr);
   std::stringstream s(std::ios::in | std::ios::out | std::ios::binary);
   sketch.serialize(s);
   cpc_sketch deserialized = cpc_sketch::deserialize(s);
-  //deserialized.to_stream(std::cerr);
   REQUIRE(deserialized.is_empty() == sketch.is_empty());
   REQUIRE(deserialized.get_estimate() == sketch.get_estimate());
   REQUIRE(deserialized.validate());
@@ -266,7 +261,7 @@ TEST_CASE("cpc sketch: serialize deserialize pinned, bytes", "[cpc_sketch]") {
   REQUIRE(deserialized.get_estimate() == sketch.get_estimate());
   REQUIRE(deserialized.validate());
 
-  //sketch.to_stream(std::cout);
+  std::cout << sketch.to_string();
 }
 
 TEST_CASE("cpc sketch: serialize deserialize sliding, bytes", "[cpc_sketch]") {

--- a/fi/include/frequent_items_sketch.hpp
+++ b/fi/include/frequent_items_sketch.hpp
@@ -27,6 +27,7 @@
 #include <type_traits>
 
 #include "reverse_purge_hash_map.hpp"
+#include "common_defs.hpp"
 #include "serde.hpp"
 
 namespace datasketches {
@@ -259,11 +260,10 @@ public:
   static frequent_items_sketch deserialize(const void* bytes, size_t size);
 
   /**
-   * Writes a human readable summary of this sketch to a given stream
-   * @param os output stream
+   * Returns a human readable summary of this sketch
    * @param print_items if true include the list of items retained by the sketch
    */
-  void to_stream(std::ostream& os, bool print_items = false) const;
+  string<A> to_string(bool print_items = false) const;
 
 private:
   static const uint8_t LG_MIN_MAP_SIZE = 3;

--- a/fi/include/frequent_items_sketch_impl.hpp
+++ b/fi/include/frequent_items_sketch_impl.hpp
@@ -423,7 +423,8 @@ void frequent_items_sketch<T, W, H, E, S, A>::check_size(uint8_t lg_cur_size, ui
 }
 
 template<typename T, typename W, typename H, typename E, typename S, typename A>
-void frequent_items_sketch<T, W, H, E, S, A>::to_stream(std::ostream& os, bool print_items) const {
+string<A> frequent_items_sketch<T, W, H, E, S, A>::to_string(bool print_items) const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### Frequent items sketch summary:" << std::endl;
   os << "   lg cur map size  : " << (int) map.get_lg_cur_size() << std::endl;
   os << "   lg max map size  : " << (int) map.get_lg_max_size() << std::endl;
@@ -446,6 +447,7 @@ void frequent_items_sketch<T, W, H, E, S, A>::to_stream(std::ostream& os, bool p
     }
     os << "### End items" << std::endl;
   }
+  return os.str();
 }
 
 // version for integral signed type

--- a/fi/test/frequent_items_sketch_custom_type_test.cpp
+++ b/fi/test/frequent_items_sketch_custom_type_test.cpp
@@ -61,7 +61,7 @@ TEST_CASE("frequent items: custom type", "[frequent_items_sketch]") {
   REQUIRE(sketch.get_maximum_error() == sketch2.get_maximum_error());
   //std::cerr << "end" << std::endl;
 
-  sketch2.to_stream(std::cerr, true);
+  std::cout << sketch2.to_string(true);
 }
 
 // this is to see the debug print from test_type if enabled there to make sure items are moved

--- a/hll/include/HllSketch-internal.hpp
+++ b/hll/include/HllSketch-internal.hpp
@@ -74,11 +74,6 @@ hll_sketch_alloc<A>::~hll_sketch_alloc() {
 }
 
 template<typename A>
-std::ostream& operator<<(std::ostream& os, const hll_sketch_alloc<A>& sketch) {
-  return sketch.to_string(os, true, true, false, false);
-}
-
-template<typename A>
 hll_sketch_alloc<A>::hll_sketch_alloc(const hll_sketch_alloc<A>& that) :
   sketch_impl(that.sketch_impl->copy())
 {}
@@ -249,21 +244,11 @@ vector_u8<A> hll_sketch_alloc<A>::serialize_updatable() const {
 }
 
 template<typename A>
-std::string hll_sketch_alloc<A>::to_string(const bool summary,
-                                    const bool detail,
-                                    const bool aux_detail,
-                                    const bool all) const {
-  std::ostringstream oss;
-  to_string(oss, summary, detail, aux_detail, all);
-  return oss.str();
-}
-
-template<typename A>
-std::ostream& hll_sketch_alloc<A>::to_string(std::ostream& os,
-                                      const bool summary,
-                                      const bool detail,
-                                      const bool aux_detail,
-                                      const bool all) const {
+string<A> hll_sketch_alloc<A>::to_string(const bool summary,
+                                         const bool detail,
+                                         const bool aux_detail,
+                                         const bool all) const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   if (summary) {
     os << "### HLL sketch summary:" << std::endl
        << "  Log Config K   : " << get_lg_config_k() << std::endl
@@ -355,7 +340,7 @@ std::ostream& hll_sketch_alloc<A>::to_string(std::ostream& os,
     }
   }
 
-  return os;
+  return os.str();
 }
 
 template<typename A>

--- a/hll/include/HllUnion-internal.hpp
+++ b/hll/include/HllUnion-internal.hpp
@@ -66,11 +66,6 @@ hll_union_alloc<A> hll_union_alloc<A>::deserialize(std::istream& is) {
 }
 
 template<typename A>
-static std::ostream& operator<<(std::ostream& os, const hll_union_alloc<A>& hllUnion) {
-  return hllUnion.to_string(os, true, true, false, false);
-}
-
-template<typename A>
 hll_sketch_alloc<A> hll_union_alloc<A>::get_result(target_hll_type target_type) const {
   return hll_sketch_alloc<A>(gadget, target_type);
 }
@@ -160,18 +155,6 @@ void hll_union_alloc<A>::coupon_update(const int coupon) {
     if (gadget.sketch_impl != nullptr) { gadget.sketch_impl->get_deleter()(gadget.sketch_impl); }
     gadget.sketch_impl = result;
   }
-}
-
-template<typename A>
-std::ostream& hll_union_alloc<A>::to_string(std::ostream& os, const bool summary,
-                                  const bool detail, const bool aux_detail, const bool all) const {
-  return gadget.to_string(os, summary, detail, aux_detail, all);
-}
-
-template<typename A>
-std::string hll_union_alloc<A>::to_string(const bool summary, const bool detail,
-                                   const bool aux_detail, const bool all) const {
-  return gadget.to_string(summary, detail, aux_detail, all);
 }
 
 template<typename A>

--- a/hll/include/hll.hpp
+++ b/hll/include/hll.hpp
@@ -20,6 +20,7 @@
 #ifndef _HLL_HPP_
 #define _HLL_HPP_
 
+#include "common_defs.hpp"
 #include "HllUtil.hpp"
 
 #include <memory>
@@ -194,31 +195,16 @@ class hll_sketch_alloc final {
 
     /**
      * Human readable summary with optional detail
-     * @param os std::ostram to which the summary is written
      * @param summary if true, output the sketch summary
      * @param detail if true, output the internal data array
      * @param auxDetail if true, output the internal Aux array, if it exists.
      * @param all if true, outputs all entries including empty ones
      * @return human readable string with optional detail.
      */
-    std::ostream& to_string(std::ostream& os,
-                            bool summary = true,
-                            bool detail = false,
-                            bool aux_detail = false,
-                            bool all = false) const;
-
-    /**
-     * Human readable summary with optional detail
-     * @param summary if true, output the sketch summary
-     * @param detail if true, output the internal data array
-     * @param auxDetail if true, output the internal Aux array, if it exists.
-     * @param all if true, outputs all entries including empty ones
-     * @return human readable string with optional detail.
-     */
-    std::string to_string(bool summary = true,
-                          bool detail = false,
-                          bool aux_detail = false,
-                          bool all = false) const;
+    string<A> to_string(bool summary = true,
+                        bool detail = false,
+                        bool aux_detail = false,
+                        bool all = false) const;
 
     /**
      * Present the given std::string as a potential unique item.
@@ -548,34 +534,6 @@ class hll_union_alloc {
     hll_sketch_alloc<A> get_result(target_hll_type tgt_type = HLL_4) const;
 
     /**
-     * Human readable summary with optional detail
-     * @param os std::ostram to which the summary is written
-     * @param summary if true, output the union summary
-     * @param detail if true, output the internal data array
-     * @param auxDetail if true, output the internal Aux array, if it exists.
-     * @param all if true, outputs all entries including empty ones
-     * @return human readable string with optional detail.
-     */
-    std::ostream& to_string(std::ostream& os,
-                            bool summary = true,
-                            bool detail = false,
-                            bool aux_Detail = false,
-                            bool all = false) const;
-  
-    /**
-     * Human readable summary with optional detail
-     * @param summary if true, output the sketch summary
-     * @param detail if true, output the internal data array
-     * @param auxDetail if true, output the internal Aux array, if it exists.
-     * @param all if true, outputs all entries including empty ones
-     * @return human readable string with optional detail.
-     */
-    std::string to_string(bool summary = true,
-                          bool detail = false,
-                          bool aux_detail = false,
-                          bool all = false) const;
-
-    /**
      * Update this union operator with the given sketch.
      * @param The given sketch.
      */
@@ -712,12 +670,6 @@ class hll_union_alloc {
     int lg_max_k;
     hll_sketch_alloc<A> gadget;
 };
-
-template<typename A>
-static std::ostream& operator<<(std::ostream& os, const hll_sketch_alloc<A>& sketch);
-
-template<typename A>
-static std::ostream& operator<<(std::ostream& os, const hll_union_alloc<A>& union_in);
 
 /// convenience alias for hll_sketch with default allocator
 typedef hll_sketch_alloc<> hll_sketch;

--- a/hll/test/HllSketchTest.cpp
+++ b/hll/test/HllSketchTest.cpp
@@ -167,14 +167,14 @@ TEST_CASE("hll sketch: exercise to string", "[hll_sketch]") {
     hll_sketch_test_alloc sk(15, HLL_4);
     for (int i = 0; i < 25; ++i) { sk.update(i); }
     std::ostringstream oss(std::ios::binary);
-    sk.to_string(oss, false, true, true, true);
+    oss << sk.to_string(false, true, true, true);
     for (int i = 25; i < (1 << 20); ++i) { sk.update(i); }
-    sk.to_string(oss, false, true, true, true);
-    sk.to_string(oss, false, true, true, false);
+    oss << sk.to_string(false, true, true, true);
+    oss << sk.to_string(false, true, true, false);
 
     sk = hll_sketch_test_alloc(8, HLL_8);
     for (int i = 0; i < 25; ++i) { sk.update(i); }
-    sk.to_string(oss, false, true, true, true);
+    oss << sk.to_string(false, true, true, true);
   }
   REQUIRE(test_allocator_total_bytes == 0);
 }
@@ -322,7 +322,7 @@ TEST_CASE("hll sketch: deserialize set mode buffer overrun", "[hll_sketch]") {
   {
     hll_sketch_test_alloc sketch(10);
     for (int i = 0; i < 10; ++i) sketch.update(i);
-    //sketch.to_string(std::cout);
+    //std::cout << sketch.to_string();
     auto bytes = sketch.serialize_updatable();
     REQUIRE_THROWS_AS(hll_sketch_test_alloc::deserialize(bytes.data(), 7), std::out_of_range);
     REQUIRE_THROWS_AS(hll_sketch_test_alloc::deserialize(bytes.data(), bytes.size() - 1), std::out_of_range);
@@ -350,7 +350,7 @@ TEST_CASE("hll sketch: deserialize HLL mode buffer overrun", "[hll_sketch]") {
     // this sketch should have aux table
     hll_sketch_test_alloc sketch(15);
     for (int i = 0; i < 14444; ++i) sketch.update(i);
-    //sketch.to_string(std::cout);
+    //std::cout << sketch.to_string();
     auto bytes = sketch.serialize_compact();
     REQUIRE_THROWS_AS(hll_sketch_test_alloc::deserialize(bytes.data(), 7), std::out_of_range);
     REQUIRE_THROWS_AS(hll_sketch_test_alloc::deserialize(bytes.data(), 15), std::out_of_range);

--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -42,6 +42,10 @@ namespace datasketches {
  * inverse functions get_rank(), get_PMF() (Probability Mass Function), and get_CDF()
  * (Cumulative Distribution Function).
  *
+ * <p>As of May 2020, this implementation produces serialized sketches which are binary-compatible
+ * with the equivalent Java implementation only when template parameter T = float
+ * (32-bit single precision values).
+ * 
  * <p>Given an input stream of <i>N</i> numeric values, the <i>absolute rank</i> of any specific
  * value is defined as its index <i>(0 to N-1)</i> in the hypothetical sorted stream of all
  * <i>N</i> input values.

--- a/kll/include/kll_sketch.hpp
+++ b/kll/include/kll_sketch.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "kll_quantile_calculator.hpp"
+#include "common_defs.hpp"
 #include "serde.hpp"
 
 namespace datasketches {
@@ -416,12 +417,11 @@ class kll_sketch {
     static double get_normalized_rank_error(uint16_t k, bool pmf);
 
     /**
-     * Prints a summary of the sketch to a given stream.
-     * @param os the provided ostream
+     * Prints a summary of the sketch.
      * @param print_levels if true include information about levels
      * @param print_items if true include sketch data
      */
-    void to_stream(std::ostream& os, bool print_levels = false, bool print_items = false) const;
+    string<A> to_string(bool print_levels = false, bool print_items = false) const;
 
     class const_iterator;
     const_iterator begin() const;

--- a/kll/include/kll_sketch_impl.hpp
+++ b/kll/include/kll_sketch_impl.hpp
@@ -990,7 +990,8 @@ void kll_sketch<T, C, S, A>::check_family_id(uint8_t family_id) {
 }
 
 template <typename T, typename C, typename S, typename A>
-void kll_sketch<T, C, S, A>::to_stream(std::ostream& os, bool print_levels, bool print_items) const {
+string<A> kll_sketch<T, C, S, A>::to_string(bool print_levels, bool print_items) const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### KLL sketch summary:" << std::endl;
   os << "   K              : " << k_ << std::endl;
   os << "   min K          : " << min_k_ << std::endl;
@@ -1036,6 +1037,7 @@ void kll_sketch<T, C, S, A>::to_stream(std::ostream& os, bool print_levels, bool
     }
     os << "### End sketch data" << std::endl;
   }
+  return os.str();
 }
 
 template <typename T, typename C, typename S, typename A>

--- a/kll/test/kll_sketch_test.cpp
+++ b/kll/test/kll_sketch_test.cpp
@@ -195,7 +195,7 @@ TEST_CASE("kll sketch", "[kll_sketch]") {
       previous_quantile = quantile;
     }
 
-    //sketch.to_stream(std::cout);
+    //std::cout << sketch.to_string();
   }
 
   SECTION("consistency between get_rank adn get_PMF/CDF") {

--- a/python/src/cpc_wrapper.cpp
+++ b/python/src/cpc_wrapper.cpp
@@ -40,12 +40,6 @@ py::object cpc_sketch_serialize(const cpc_sketch& sk) {
   return py::bytes((char*)serResult.data(), serResult.size());
 }
 
-std::string cpc_sketch_to_string(const cpc_sketch& sk) {
-  std::ostringstream ss;
-  sk.to_stream(ss);
-  return ss.str();
-}
-
 cpc_sketch* cpc_union_get_result(const cpc_union& u) {
   return new cpc_sketch(u.get_result());
 }
@@ -61,7 +55,8 @@ void init_cpc(py::module &m) {
   py::class_<cpc_sketch>(m, "cpc_sketch")
     .def(py::init<uint8_t, uint64_t>(), py::arg("lg_k"), py::arg("seed")=DEFAULT_SEED)
     .def(py::init<const cpc_sketch&>())
-    .def("__str__", &dspy::cpc_sketch_to_string)
+    .def("__str__", &cpc_sketch::to_string)
+    .def("to_string", &cpc_sketch::to_string)
     .def("serialize", &dspy::cpc_sketch_serialize)
     .def_static("deserialize", &dspy::cpc_sketch_deserialize)
     .def<void (cpc_sketch::*)(uint64_t)>("update", &cpc_sketch::update, py::arg("datum"))

--- a/python/src/fi_wrapper.cpp
+++ b/python/src/fi_wrapper.cpp
@@ -64,14 +64,6 @@ py::list fi_sketch_get_frequent_items(const frequent_items_sketch<T>& sk,
   return list;
 }
 
-template<typename T>
-std::string fi_sketch_to_string(const frequent_items_sketch<T>& sk,
-                              bool print_items = false) {
-  std::ostringstream ss;
-  sk.to_stream(ss, print_items);
-  return ss.str();
-}
-
 }
 }
 
@@ -83,8 +75,8 @@ void bind_fi_sketch(py::module &m, const char* name) {
 
   py::class_<frequent_items_sketch<T>>(m, name)
     .def(py::init<uint8_t>(), py::arg("lg_max_k"))
-    .def("__str__", &dspy::fi_sketch_to_string<T>, py::arg("print_items")=false)
-    .def("to_string", &dspy::fi_sketch_to_string<T>, py::arg("print_items")=false)
+    .def("__str__", &frequent_items_sketch<T>::to_string, py::arg("print_items")=false)
+    .def("to_string", &frequent_items_sketch<T>::to_string, py::arg("print_items")=false)
     .def("update", (void (frequent_items_sketch<T>::*)(const T&, uint64_t)) &frequent_items_sketch<T>::update, py::arg("item"), py::arg("weight")=1)
     .def("get_frequent_items", &dspy::fi_sketch_get_frequent_items<T>, py::arg("err_type"), py::arg("threshold")=0)
     .def("merge", (void (frequent_items_sketch<T>::*)(const frequent_items_sketch<T>&)) &frequent_items_sketch<T>::merge)

--- a/python/src/hll_wrapper.cpp
+++ b/python/src/hll_wrapper.cpp
@@ -62,9 +62,9 @@ void init_hll(py::module &m) {
     .def_static("deserialize", &dspy::hll_sketch_deserialize)
     .def("serialize_compact", &dspy::hll_sketch_serialize_compact)
     .def("serialize_updatable", &dspy::hll_sketch_serialize_updatable)
-    .def("to_string", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
-         py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
     .def("__str__", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
+         py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
+    .def("to_string", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
          py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
     .def_property_readonly("lg_config_k", &hll_sketch::get_lg_config_k)
     .def_property_readonly("tgt_type", &hll_sketch::get_target_type)
@@ -87,10 +87,6 @@ void init_hll(py::module &m) {
 
   py::class_<hll_union>(m, "hll_union")
     .def(py::init<int>(), py::arg("lg_max_k"))
-    .def("to_string", (std::string (hll_union::*)(bool,bool,bool,bool) const) &hll_union::to_string,
-         py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
-    .def("__str__", (std::string (hll_union::*)(bool,bool,bool,bool) const) &hll_union::to_string,
-         py::arg("summary")=true, py::arg("detail")=false, py::arg("aux_detail")=false, py::arg("all")=false)
     .def_property_readonly("lg_config_k", &hll_union::get_lg_config_k)
     .def_property_readonly("tgt_type", &hll_union::get_target_type)
     .def("get_estimate", &hll_union::get_estimate)

--- a/python/src/kll_wrapper.cpp
+++ b/python/src/kll_wrapper.cpp
@@ -90,13 +90,6 @@ py::list kll_sketch_get_cdf(const kll_sketch<T>& sk,
   return list;
 }
 
-template<typename T>
-std::string kll_sketch_to_string(const kll_sketch<T>& sk) {
-  std::ostringstream ss;
-  sk.to_stream(ss);
-  return ss.str();
-}
-
 }
 }
 
@@ -111,7 +104,8 @@ void bind_kll_sketch(py::module &m, const char* name) {
     .def(py::init<const kll_sketch<T>&>())
     .def("update", (void (kll_sketch<T>::*)(const T&)) &kll_sketch<T>::update, py::arg("item"))
     .def("merge", (void (kll_sketch<T>::*)(const kll_sketch<T>&)) &kll_sketch<T>::merge, py::arg("sketch"))
-    .def("__str__", &dspy::kll_sketch_to_string<T>)
+    .def("__str__", &kll_sketch<T>::to_string, py::arg("print_levels")=false, py::arg("print_items")=false)
+    .def("to_string", &kll_sketch<T>::to_string, py::arg("print_levels")=false, py::arg("print_items")=false)
     .def("is_empty", &kll_sketch<T>::is_empty)
     .def("get_n", &kll_sketch<T>::get_n)
     .def("get_num_retained", &kll_sketch<T>::get_num_retained)

--- a/python/src/theta_wrapper.cpp
+++ b/python/src/theta_wrapper.cpp
@@ -58,13 +58,6 @@ py::object theta_sketch_serialize(const theta_sketch& sk) {
   return py::bytes((char*)serResult.data(), serResult.size());
 }
 
-std::string theta_sketch_to_string(const theta_sketch& sk,
-                                   bool print_items = false) {
-  std::ostringstream ss;
-  sk.to_stream(ss, print_items);
-  return ss.str();
-}
-
 uint16_t theta_sketch_get_seed_hash(const theta_sketch& sk) {
   return sk.get_seed_hash();
 }
@@ -90,8 +83,8 @@ void init_theta(py::module &m) {
   py::class_<theta_sketch>(m, "theta_sketch")
     .def("serialize", &dspy::theta_sketch_serialize)
     .def_static("deserialize", &dspy::theta_sketch_deserialize, py::arg("bytes"), py::arg("seed")=DEFAULT_SEED)
-    .def("__str__", &dspy::theta_sketch_to_string, py::arg("print_items")=false)
-    .def("to_string", &dspy::theta_sketch_to_string, py::arg("print_items")=false)
+    .def("__str__", &theta_sketch::to_string, py::arg("print_items")=false)
+    .def("to_string", &theta_sketch::to_string, py::arg("print_items")=false)
     .def("is_empty", &theta_sketch::is_empty)
     .def("get_estimate", &theta_sketch::get_estimate)
     .def("get_upper_bound", &theta_sketch::get_upper_bound, py::arg("num_std_devs"))

--- a/python/src/vo_wrapper.cpp
+++ b/python/src/vo_wrapper.cpp
@@ -54,7 +54,7 @@ template<typename T>
 std::string vo_sketch_to_string(const var_opt_sketch<T>& sk, bool print_items) {
   if (print_items) {
     std::ostringstream ss;
-    sk.to_stream(ss);
+    ss << sk.to_string();
     ss << "### VarOpt Sketch Items" << std::endl;
     int i = 0;
     for (auto& item : sk) {
@@ -70,13 +70,6 @@ std::string vo_sketch_to_string(const var_opt_sketch<T>& sk, bool print_items) {
   } else {
     return sk.to_string();
   }
-}
-
-template<typename T>
-std::string vo_union_to_string(const var_opt_union<T>& u) {
-  // no direct access to gadget so we can't easily print the item list
-  // for arbitrary python objects
-  return u.to_string();
 }
 
 }
@@ -113,8 +106,8 @@ void bind_vo_union(py::module &m, const char* name) {
 
   py::class_<var_opt_union<T>>(m, name)
     .def(py::init<uint32_t>(), py::arg("max_k"))
-    .def("__str__", &dspy::vo_union_to_string<T>)
-    .def("to_string", &dspy::vo_union_to_string<T>)
+    .def("__str__", &var_opt_union<T>::to_string)
+    .def("to_string", &var_opt_union<T>::to_string)
     .def("update", (void (var_opt_union<T>::*)(const var_opt_sketch<T>& sk)) &var_opt_union<T>::update, py::arg("sketch"))
     .def("get_result", &var_opt_union<T>::get_result)
     .def("reset", &var_opt_union<T>::reset)

--- a/python/tests/vo_test.py
+++ b/python/tests/vo_test.py
@@ -87,13 +87,15 @@ class VoTest(unittest.TestCase):
 
     # we can compare what information is available from both
     # the union and a sketch.
-    union_str = union.to_string()
+    print(union)
 
     # if we want to print the list of itmes, there must be a
     # __str__() method for each item (which need not be the same
     # type; they're all generic python objects when used from
-    # pythoh), otherwise you may trigger an exception
-    result_str = result.to_string(True)
+    # python), otherwise you may trigger an exception.
+    # to_string() is provided as a convenince to avoid direct
+    # calls to __str__() with parameters.
+    print(result.to_string(True))
 
 if __name__ == '__main__':
   unittest.main()

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -21,6 +21,7 @@
 #define _VAR_OPT_SKETCH_HPP_
 
 #include "serde.hpp"
+#include "common_defs.hpp"
 
 #include <iterator>
 #include <vector>
@@ -178,36 +179,19 @@ class var_opt_sketch {
     static var_opt_sketch deserialize(const void* bytes, size_t size);
 
     /**
-     * Prints a summary of the sketch to a given stream.
-     * @param os the provided ostream
-     * @return the ostream
-     */
-    std::ostream& to_stream(std::ostream& os) const;
-  
-    /**
-     * Prints a summary of the sketch as a string.
+     * Prints a summary of the sketch.
      * @return the summary as a string
      */
-    std::string to_string() const;
-
-    /**
-     * Prints the raw sketch items to a given ostream.
-     * Only works for type T with a defined operator<<() and
-     * kept separate from to_stream() to allow compilation even if
-     * T does not have such an operator defined.
-     * @param os the provided ostream
-     * @return the provided ostream
-     */
-    std::ostream& items_to_stream(std::ostream& os) const;
+    string<A> to_string() const;
 
     /**
      * Prints the raw sketch items to a string. Calls items_to_stream() internally.
      * Only works for type T with a defined operator<<() and
-     * kept separate from to_stream() to allow compilation even if
+     * kept separate from to_string() to allow compilation even if
      * T does not have such an operator defined.
      * @return a string with the sketch items
      */
-    std::string items_to_string() const;
+    string<A> items_to_string() const;
 
     class const_iterator;
     const_iterator begin() const;

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -724,7 +724,8 @@ void var_opt_sketch<T,S,A>::update(T&& item, double weight) {
 */
 
 template<typename T, typename S, typename A>
-std::ostream& var_opt_sketch<T,S,A>::to_stream(std::ostream& os) const {
+string<A> var_opt_sketch<T,S,A>::to_string() const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### VarOpt SUMMARY: " << std::endl;
   os << "   k            : " << k_ << std::endl;
   os << "   h            : " << h_ << std::endl;
@@ -733,14 +734,13 @@ std::ostream& var_opt_sketch<T,S,A>::to_stream(std::ostream& os) const {
   os << "   Current size : " << curr_items_alloc_ << std::endl;
   os << "   Resize factor: " << (1 << rf_) << std::endl;
   os << "### END SKETCH SUMMARY" << std::endl;
-
-  return os;
+  return os.str();
 }
 
 template<typename T, typename S, typename A>
-std::ostream& var_opt_sketch<T,S,A>::items_to_stream(std::ostream& os) const {
+string<A> var_opt_sketch<T,S,A>::items_to_string() const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### Sketch Items" << std::endl;
-
   const uint32_t print_length = (n_ < k_ ? n_ : k_ + 1);
   for (uint32_t i = 0; i < print_length; ++i) {
     if (i == h_) {
@@ -749,22 +749,7 @@ std::ostream& var_opt_sketch<T,S,A>::items_to_stream(std::ostream& os) const {
       os << i << ": " << data_[i] << "\twt = " << weights_[i] << std::endl;
     }
   }
-
-  return os;
-}
-
-template <typename T, typename S, typename A>
-std::string var_opt_sketch<T,S,A>::to_string() const {
-  std::ostringstream ss;
-  to_stream(ss);
-  return ss.str();
-}
-
-template <typename T, typename S, typename A>
-std::string var_opt_sketch<T,S,A>::items_to_string() const {
-  std::ostringstream ss;
-  items_to_stream(ss);
-  return ss.str();
+  return os.str();
 }
 
 template<typename T, typename S, typename A>

--- a/sampling/include/var_opt_union.hpp
+++ b/sampling/include/var_opt_union.hpp
@@ -21,6 +21,7 @@
 #define _VAR_OPT_UNION_HPP_
 
 #include "var_opt_sketch.hpp"
+#include "common_defs.hpp"
 #include "serde.hpp"
 
 #include <vector>
@@ -131,17 +132,10 @@ public:
   static var_opt_union deserialize(const void* bytes, size_t size);
 
   /**
-   * Prints a summary of the union to a given stream.
-   * @param os the provided ostream
-   * @return the ostream
-   */
-  std::ostream& to_stream(std::ostream& os) const;
-
-  /**
    * Prints a summary of the union as a string.
    * @return the summary as a string
    */
-  std::string to_string() const;
+  string<A> to_string() const;
 
 
 private:

--- a/sampling/include/var_opt_union_impl.hpp
+++ b/sampling/include/var_opt_union_impl.hpp
@@ -296,22 +296,15 @@ void var_opt_union<T,S,A>::reset() {
 }
 
 template<typename T, typename S, typename A>
-std::ostream& var_opt_union<T,S,A>::to_stream(std::ostream& os) const {
+string<A> var_opt_union<T,S,A>::to_string() const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### VarOpt Union SUMMARY: " << std::endl;
   os << " . n             : " << n_ << std::endl;
   os << "   Max k         : " << max_k_ << std::endl;
   os << "   Gadget Summary: " << std::endl;
-  gadget_.to_stream(os);
+  os << gadget_.to_string();
   os << "### END VarOpt Union SUMMARY: " << std::endl;
-
-  return os;
-}
-
-template<typename T, typename S, typename A>
-std::string var_opt_union<T,S,A>::to_string() const {
-  std::ostringstream ss;
-  to_stream(ss);
-  return ss.str();
+  return os.str();
 }
 
 template<typename T, typename S, typename A>

--- a/theta/include/theta_sketch.hpp
+++ b/theta/include/theta_sketch.hpp
@@ -112,10 +112,9 @@ public:
 
   /**
    * Writes a human-readable summary of this sketch to a given stream
-   * @param os output stream
    * @param print_items if true include the list of items retained by the sketch
    */
-  virtual void to_stream(std::ostream& os, bool print_items = false) const = 0;
+  virtual string<A> to_string(bool print_items = false) const = 0;
 
   /**
    * This method serializes the sketch into a given stream in a binary form
@@ -210,7 +209,7 @@ public:
   virtual uint32_t get_num_retained() const;
   virtual uint16_t get_seed_hash() const;
   virtual bool is_ordered() const;
-  virtual void to_stream(std::ostream& os, bool print_items = false) const;
+  virtual string<A> to_string(bool print_items = false) const;
   virtual void serialize(std::ostream& os) const;
   typedef vector_u8<A> vector_bytes; // alias for users
   // header space is reserved, but not initialized
@@ -398,7 +397,7 @@ public:
   virtual uint32_t get_num_retained() const;
   virtual uint16_t get_seed_hash() const;
   virtual bool is_ordered() const;
-  virtual void to_stream(std::ostream& os, bool print_items = false) const;
+  virtual string<A> to_string(bool print_items = false) const;
   virtual void serialize(std::ostream& os) const;
   typedef vector_u8<A> vector_bytes; // alias for users
   // header space is reserved, but not initialized

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <istream>
 #include <ostream>
+#include <sstream>
 
 #include "MurmurHash3.h"
 #include "serde.hpp"
@@ -248,7 +249,8 @@ bool update_theta_sketch_alloc<A>::is_ordered() const {
 }
 
 template<typename A>
-void update_theta_sketch_alloc<A>::to_stream(std::ostream& os, bool print_items) const {
+string<A> update_theta_sketch_alloc<A>::to_string(bool print_items) const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### Update Theta sketch summary:" << std::endl;
   os << "   lg nominal size      : " << (int) lg_nom_size_ << std::endl;
   os << "   lg current size      : " << (int) lg_cur_size_ << std::endl;
@@ -270,6 +272,7 @@ void update_theta_sketch_alloc<A>::to_stream(std::ostream& os, bool print_items)
     for (auto key: *this) os << "   " << key << std::endl;
     os << "### End retained keys" << std::endl;
   }
+  return os.str();
 }
 
 template<typename A>
@@ -637,7 +640,8 @@ bool compact_theta_sketch_alloc<A>::is_ordered() const {
 }
 
 template<typename A>
-void compact_theta_sketch_alloc<A>::to_stream(std::ostream& os, bool print_items) const {
+string<A> compact_theta_sketch_alloc<A>::to_string(bool print_items) const {
+  std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### Compact Theta sketch summary:" << std::endl;
   os << "   num retained keys    : " << keys_.size() << std::endl;
   os << "   seed hash            : " << this->get_seed_hash() << std::endl;
@@ -655,6 +659,7 @@ void compact_theta_sketch_alloc<A>::to_stream(std::ostream& os, bool print_items
     for (auto key: *this) os << "   " << key << std::endl;
     os << "### End retained keys" << std::endl;
   }
+  return os.str();
 }
 
 template<typename A>

--- a/theta/test/theta_sketch_test.cpp
+++ b/theta/test/theta_sketch_test.cpp
@@ -52,7 +52,7 @@ TEST_CASE("theta sketch: empty", "[theta_sketch]") {
 TEST_CASE("theta sketch: non empty no retained keys", "[theta_sketch]") {
   update_theta_sketch update_sketch = update_theta_sketch::builder().set_p(0.001).build();
   update_sketch.update(1);
-  //update_sketch.to_stream(std::cerr);
+  //std::cerr << update_sketch.to_string();
   REQUIRE(update_sketch.get_num_retained() == 0);
   REQUIRE_FALSE(update_sketch.is_empty());
   REQUIRE(update_sketch.is_estimation_mode());
@@ -111,7 +111,7 @@ TEST_CASE("theta sketch: estimation", "[theta_sketch]") {
   update_theta_sketch update_sketch = update_theta_sketch::builder().set_resize_factor(update_theta_sketch::resize_factor::X1).build();
   const int n = 8000;
   for (int i = 0; i < n; i++) update_sketch.update(i);
-  //update_sketch.to_stream(std::cerr);
+  //std::cerr << update_sketch.to_string();
   REQUIRE_FALSE(update_sketch.is_empty());
   REQUIRE(update_sketch.is_estimation_mode());
   REQUIRE(update_sketch.get_theta() < 1.0);

--- a/theta/test/theta_union_test.cpp
+++ b/theta/test/theta_union_test.cpp
@@ -84,7 +84,7 @@ TEST_CASE("theta union: estimation mode half overlap", "[theta_union]") {
   REQUIRE_FALSE(sketch3.is_empty());
   REQUIRE(sketch3.is_estimation_mode());
   REQUIRE(sketch3.get_estimate() == Approx(15000).margin(15000 * 0.01));
-  //sketch3.to_stream(std::cerr, true);
+  //std::cerr << sketch3.to_string(true);
 }
 
 TEST_CASE("theta union: seed mismatch", "[theta_union]") {


### PR DESCRIPTION
standardize on to_string for all sketches, returning a string created using the allocator that the sketch uses.