### PR TITLE
check istream status before returning from deserialize

### DIFF
--- a/cpc/include/cpc_sketch_impl.hpp
+++ b/cpc/include/cpc_sketch_impl.hpp
@@ -582,6 +582,8 @@ cpc_sketch_alloc<A> cpc_sketch_alloc<A>::deserialize(std::istream& is, uint64_t 
   }
   uncompressed_state<A> uncompressed;
   get_compressor<A>().uncompress(compressed, uncompressed, lg_k, num_coupons);
+  if (!is.good())
+    throw std::runtime_error("error reading from std::istream"); 
   return cpc_sketch_alloc(lg_k, num_coupons, first_interesting_column, std::move(uncompressed.table),
       std::move(uncompressed.window), has_hip, kxp, hip_est_accum, seed);
 }

--- a/fi/include/frequent_items_sketch_impl.hpp
+++ b/fi/include/frequent_items_sketch_impl.hpp
@@ -323,6 +323,8 @@ frequent_items_sketch<T, W, H, E, S, A> frequent_items_sketch<T, W, H, E, S, A>:
     sketch.total_weight = total_weight;
     sketch.offset = offset;
   }
+  if (!is.good())
+    throw std::runtime_error("error reading from std::istream"); 
   return sketch;
 }
 

--- a/hll/include/CouponHashSet-internal.hpp
+++ b/hll/include/CouponHashSet-internal.hpp
@@ -190,6 +190,9 @@ CouponHashSet<A>* CouponHashSet<A>::newSet(std::istream& is) {
     is.read((char*)sketch->couponIntArr, (1 << sketch->lgCouponArrInts) * sizeof(int));
   } 
 
+  if (!is.good())
+    throw std::runtime_error("error reading from std::istream"); 
+
   return ptr.release();
 }
 

--- a/hll/include/CouponList-internal.hpp
+++ b/hll/include/CouponList-internal.hpp
@@ -187,6 +187,9 @@ CouponList<A>* CouponList<A>::newList(std::istream& is) {
     is.read((char*)sketch->couponIntArr, numToRead * sizeof(int));
   }
 
+  if (!is.good())
+    throw std::runtime_error("error reading from std::istream"); 
+
   return ptr.release();
 }
 

--- a/hll/include/HllArray-internal.hpp
+++ b/hll/include/HllArray-internal.hpp
@@ -219,6 +219,9 @@ HllArray<A>* HllArray<A>::newHll(std::istream& is) {
     ((Hll4Array<A>*)sketch)->putAuxHashMap(auxHashMap);
   }
 
+  if (!is.good())
+    throw std::runtime_error("error reading from std::istream"); 
+
   return sketch_ptr.release();
 }
 

--- a/kll/include/kll_sketch_impl.hpp
+++ b/kll/include/kll_sketch_impl.hpp
@@ -469,6 +469,7 @@ kll_sketch<T, C, S, A> kll_sketch<T, C, S, A>::deserialize(std::istream& is) {
   check_family_id(family_id);
 
   const bool is_empty(flags_byte & (1 << flags::IS_EMPTY));
+  if (!is.good()) throw std::runtime_error("error reading from std::istream"); 
   if (is_empty) return kll_sketch<T, C, S, A>(k);
 
   uint64_t n;
@@ -522,6 +523,8 @@ kll_sketch<T, C, S, A> kll_sketch<T, C, S, A>::deserialize(std::istream& is) {
     // copy did not throw, repackage with destrtuctor
     max_value = std::unique_ptr<T, item_deleter>(max_value_buffer.release(), item_deleter());
   }
+  if (!is.good())
+    throw std::runtime_error("error reading from std::istream");
   return kll_sketch(k, min_k, n, num_levels, std::move(levels), std::move(items), capacity,
       std::move(min_value), std::move(max_value), is_level_zero_sorted);
 }

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -582,7 +582,10 @@ var_opt_sketch<T,S,A> var_opt_sketch<T,S,A>::deserialize(std::istream& is) {
   const bool is_gadget = flags & GADGET_FLAG_MASK;
 
   if (is_empty) {
-    return var_opt_sketch<T,S,A>(k, rf, is_gadget);
+    if (!is.good())
+      throw std::runtime_error("error reading from std::istream"); 
+    else
+      return var_opt_sketch<T,S,A>(k, rf, is_gadget);
   }
 
   // second and third prelongs
@@ -641,6 +644,9 @@ var_opt_sketch<T,S,A> var_opt_sketch<T,S,A>::deserialize(std::istream& is) {
   
   S().deserialize(is, &(items.get()[h + 1]), r);
   items.get_deleter().set_r(r); // serde didn't throw, so the items are now valid
+
+  if (!is.good())
+    throw std::runtime_error("error reading from std::istream"); 
 
   return var_opt_sketch(k, h, (r > 0 ? 1 : 0), r, n, total_wt_r, rf, array_size, false,
                         std::move(items), std::move(weights), num_marks_in_h, std::move(marks));

--- a/sampling/include/var_opt_union_impl.hpp
+++ b/sampling/include/var_opt_union_impl.hpp
@@ -150,7 +150,10 @@ var_opt_union<T,S,A> var_opt_union<T,S,A>::deserialize(std::istream& is) {
   bool is_empty = flags & EMPTY_FLAG_MASK;
   
   if (is_empty) {
-    return var_opt_union<T,S,A>(max_k);
+    if (!is.good())
+      throw std::runtime_error("error reading from std::istream"); 
+    else
+      return var_opt_union<T,S,A>(max_k);
   }
 
   uint64_t items_seen;
@@ -161,6 +164,9 @@ var_opt_union<T,S,A> var_opt_union<T,S,A>::deserialize(std::istream& is) {
   is.read((char*)&outer_tau_denom, sizeof(outer_tau_denom));
 
   var_opt_sketch<T,S,A> gadget = var_opt_sketch<T,S,A>::deserialize(is);
+
+  if (!is.good())
+    throw std::runtime_error("error reading from std::istream"); 
 
   return var_opt_union<T,S,A>(items_seen, outer_tau_numer, outer_tau_denom, max_k, std::move(gadget));
 }

--- a/theta/include/theta_sketch_impl.hpp
+++ b/theta/include/theta_sketch_impl.hpp
@@ -358,6 +358,7 @@ update_theta_sketch_alloc<A> update_theta_sketch_alloc<A>::internal_deserialize(
   vector_u64<A> keys(1 << lg_cur_size);
   is.read((char*)keys.data(), sizeof(uint64_t) * keys.size());
   const bool is_empty = flags_byte & (1 << theta_sketch_alloc<A>::flags::IS_EMPTY);
+  if (!is.good()) throw std::runtime_error("error reading from std::istream"); 
   return update_theta_sketch_alloc<A>(is_empty, theta, lg_cur_size, lg_nom_size, std::move(keys), num_keys, rf, p, seed);
 }
 
@@ -773,6 +774,7 @@ compact_theta_sketch_alloc<A> compact_theta_sketch_alloc<A>::internal_deserializ
   if (!is_empty) is.read((char*)keys.data(), sizeof(uint64_t) * keys.size());
 
   const bool is_ordered = flags_byte & (1 << theta_sketch_alloc<A>::flags::IS_ORDERED);
+  if (!is.good()) throw std::runtime_error("error reading from std::istream"); 
   return compact_theta_sketch_alloc<A>(is_empty, theta, std::move(keys), seed_hash, is_ordered);
 }
 


### PR DESCRIPTION
This might not work properly if custom serdes try using the >> operator to read strings, but that seems rather fragile for reading an array of things anyway. Maybe we should have an explicit comment in the serde header, though?