### PR TITLE
Varopt move update()

### DIFF
--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -259,12 +259,12 @@ class var_opt_sketch {
                    uint32_t curr_items_alloc, bool filled_data, std::unique_ptr<T, items_deleter> items,
                    std::unique_ptr<double, weights_deleter> weights, uint32_t num_marks_in_h,
                    std::unique_ptr<bool, marks_deleter> marks);
-    //var_opt_sketch(uint32_t k, resize_factor rf, bool is_gadget, uint8_t preamble_longs, std::istream& is);
-    //var_opt_sketch(uint32_t k, resize_factor rf, bool is_gadget, uint8_t preamble_longs, const void* bytes, size_t size);
 
     friend class var_opt_union<T,S,A>;
     var_opt_sketch(const var_opt_sketch& other, bool as_sketch, uint64_t adjusted_n);
     var_opt_sketch(T* data, double* weights, size_t len, uint32_t k, uint64_t n, uint32_t h_count, uint32_t r_count, double total_wt_r);
+
+    string<A> items_to_string(bool print_gap) const;
 
     // internal-use-only update
     template<typename O>

--- a/sampling/include/var_opt_sketch.hpp
+++ b/sampling/include/var_opt_sketch.hpp
@@ -345,7 +345,7 @@ private:
   
   // iterates over only one of the H or R region, optionally applying weight correction
   // to R region (can correct for numerical precision issues)
-  const_iterator(const var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region, bool weight_corr);
+  const_iterator(const var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region);
 
   bool get_mark() const;
 
@@ -374,7 +374,7 @@ private:
   
   // iterates over only one of the H or R region, applying weight correction
   // if iterating over R region (can correct for numerical precision issues)
-  iterator(var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region);
+  iterator(const var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region);
 
   bool get_mark() const;
 

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -63,9 +63,9 @@ var_opt_sketch<T,S,A>::var_opt_sketch(const var_opt_sketch& other) :
     data_ = A().allocate(curr_items_alloc_);
     // skip gap or anything unused at the end
     for (size_t i = 0; i < h_; ++i)
-      A().construct(&data_[i], T(other.data_[i]));
+      new (&data_[i]) T(other.data_[i]);
     for (size_t i = h_ + 1; i < h_ + r_ + 1; ++i)
-      A().construct(&data_[i], T(other.data_[i]));
+      new (&data_[i]) T(other.data_[i]);
 
     // we skipped the gap
     filled_data_ = false;
@@ -99,9 +99,9 @@ var_opt_sketch<T,S,A>::var_opt_sketch(const var_opt_sketch& other, bool as_sketc
     data_ = A().allocate(curr_items_alloc_);
     // skip gap or anything unused at the end
     for (size_t i = 0; i < h_; ++i)
-      A().construct(&data_[i], T(other.data_[i]));
+      new (&data_[i]) T(other.data_[i]);
     for (size_t i = h_ + 1; i < h_ + r_ + 1; ++i)
-      A().construct(&data_[i], T(other.data_[i]));
+      new (&data_[i]) T(other.data_[i]);
     
     // we skipped the gap
     filled_data_ = false;
@@ -723,11 +723,10 @@ void var_opt_sketch<T,S,A>::update(const T& item, double weight) {
   update(item, weight, false);
 }
 
-/*
 template<typename T, typename S, typename A>
 void var_opt_sketch<T,S,A>::update(T&& item, double weight) {
+  update(std::move(item), weight, false);
 }
-*/
 
 template<typename T, typename S, typename A>
 string<A> var_opt_sketch<T,S,A>::to_string() const {
@@ -759,7 +758,8 @@ string<A> var_opt_sketch<T,S,A>::items_to_string() const {
 }
 
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::update(const T& item, double weight, bool mark) {
+template<typename O>
+void var_opt_sketch<T,S,A>::update(O&& item, double weight, bool mark) {
   if (weight < 0.0 || std::isnan(weight) || std::isinf(weight)) {
     throw std::invalid_argument("Item weights must be nonnegativge and finite. Found: "
                                 + std::to_string(weight));
@@ -770,7 +770,7 @@ void var_opt_sketch<T,S,A>::update(const T& item, double weight, bool mark) {
 
   if (r_ == 0) {
     // exact mode
-    update_warmup_phase(item, weight, mark);
+    update_warmup_phase(std::forward<O>(item), weight, mark);
   } else {
     // sketch is in estimation mode so we can make the following check,
     // although very conservative to check every time
@@ -788,17 +788,18 @@ void var_opt_sketch<T,S,A>::update(const T& item, double weight, bool mark) {
     const double condition2 = weight < hypothetical_tau;
   
     if (condition1 && condition2) {
-      update_light(item, weight, mark);
+      update_light(std::forward<O>(item), weight, mark);
     } else if (r_ == 1) {
-      update_heavy_r_eq1(item, weight, mark);
+      update_heavy_r_eq1(std::forward<O>(item), weight, mark);
     } else {
-      update_heavy_general(item, weight, mark);
+      update_heavy_general(std::forward<O>(item), weight, mark);
     }
   }
 }
 
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::update_warmup_phase(const T& item, double weight, bool mark) {
+template<typename O>
+void var_opt_sketch<T,S,A>::update_warmup_phase(O&& item, double weight, bool mark) {
   // seems overly cautious
   if (r_ > 0 || m_ != 0 || h_ > k_) throw std::logic_error("invalid sketch state during warmup");
 
@@ -807,7 +808,7 @@ void var_opt_sketch<T,S,A>::update_warmup_phase(const T& item, double weight, bo
   }
 
   // store items as they come in until full
-  A().construct(&data_[h_], T(item));
+  new (&data_[h_]) T(std::forward<O>(item));
   weights_[h_] = weight;
   if (marks_ != nullptr) {
     marks_[h_] = mark;
@@ -827,14 +828,15 @@ void var_opt_sketch<T,S,A>::update_warmup_phase(const T& item, double weight, bo
    list. It is easy to prove that it is light enough to be part of this
    round's downsampling */
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::update_light(const T& item, double weight, bool mark) {
+template<typename O>
+void var_opt_sketch<T,S,A>::update_light(O&& item, double weight, bool mark) {
   if (r_ == 0 || (r_ + h_) != k_) throw std::logic_error("invalid sketch state during light warmup");
 
   const uint32_t m_slot = h_; // index of the gap, which becomes the M region
   if (filled_data_) {
-    data_[m_slot] = item;
+    data_[m_slot] = std::forward<O>(item);
   } else {
-    A().construct(&data_[m_slot], T(item));
+    new (&data_[m_slot]) T(std::forward<O>(item));
     filled_data_ = true;
   }
   weights_[m_slot] = weight;
@@ -853,11 +855,12 @@ void var_opt_sketch<T,S,A>::update_light(const T& item, double weight, bool mark
    but that should be okay because pseudo_heavy items cannot predominate
    in long streams unless (max wt) / (min wt) > o(exp(N)) */
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::update_heavy_general(const T& item, double weight, bool mark) {
+template<typename O>
+void var_opt_sketch<T,S,A>::update_heavy_general(O&& item, double weight, bool mark) {
   if (r_ < 2 || m_ != 0 || (r_ + h_) != k_) throw std::logic_error("invalid sketch state during heavy general update");
 
   // put into H, although may come back out momentarily
-  push(item, weight, mark);
+  push(std::forward<O>(item), weight, mark);
 
   grow_candidate_set(total_wt_r_, r_);
 }
@@ -866,10 +869,11 @@ void var_opt_sketch<T,S,A>::update_heavy_general(const T& item, double weight, b
    The one small technical difference is that since R < 2, we must grab an M item
    to have a valid starting point for continue_by_growing_candidate_set () */
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::update_heavy_r_eq1(const T& item, double weight, bool mark) {
+template<typename O>
+void var_opt_sketch<T,S,A>::update_heavy_r_eq1(O&& item, double weight, bool mark) {
   if (r_ != 1 || m_ != 0 || (r_ + h_) != k_) throw std::logic_error("invalid sketch state during heavy r=1 update");
 
-  push(item, weight, mark);  // new item into H
+  push(std::forward<O>(item), weight, mark);  // new item into H
   pop_min_to_m_region();     // pop lightest back into M
 
   // Any set of two items is downsample-able to one item,
@@ -971,7 +975,7 @@ void var_opt_sketch<T,S,A>::grow_data_arrays() {
     double* tmp_weights = AllocDouble().allocate(curr_items_alloc_);
 
     for (uint32_t i = 0; i < prev_size; ++i) {
-      A().construct(&tmp_data[i], std::move(data_[i]));
+      new (&tmp_data[i]) T(std::move(data_[i]));
       A().destroy(data_ + i);
       tmp_weights[i] = weights_[i];
     }
@@ -1076,11 +1080,12 @@ void var_opt_sketch<T,S,A>::restore_towards_root(uint32_t slot_in) {
 }
 
 template<typename T, typename S, typename A>
-void var_opt_sketch<T,S,A>::push(const T& item, double wt, bool mark) {
+template<typename O>
+void var_opt_sketch<T,S,A>::push(O&& item, double wt, bool mark) {
   if (filled_data_) {
-    data_[h_] = item;
+    data_[h_] = std::forward<O>(item);
   } else {
-    A().construct(&data_[h_], T(item));
+    new (&data_[h_]) T(std::forward<O>(item));
     filled_data_ = true;
   }
   weights_[h_] = wt;
@@ -1572,6 +1577,88 @@ template<typename T, typename S, typename A>
 bool var_opt_sketch<T, S, A>::const_iterator::get_mark() const {
   return sk_->marks_ == nullptr ? false : sk_->marks_[idx_];
 }
+
+
+// -------- var_opt_sketch::iterator implementation ---------
+
+template<typename T, typename S, typename A>
+var_opt_sketch<T,S,A>::iterator::iterator(var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region) :
+  sk_(&sk),
+  cum_r_weight_(0.0),
+  r_item_wt_(sk.get_tau()),
+  final_idx_(sk.h_ + (use_r_region ? 1 + sk.r_ : 0))
+{
+  if (use_r_region) {
+    idx_ = sk.h_ + 1 + (is_end ? sk.r_ : 0);
+  } else { // H region
+    // gap at start only if h_ == 0, so index always starts at 0
+    idx_ = (is_end ? sk.h_ : 0);
+  }
+  
+  // unlike in full iterator case, may happen even if sketch is not empty
+  if (idx_ == final_idx_) { sk_ = nullptr; }
+}
+
+template<typename T,  typename S, typename A>
+var_opt_sketch<T, S, A>::iterator::iterator(const iterator& other) :
+  sk_(other.sk_),
+  cum_r_weight_(other.cum_r_weight_),
+  r_item_wt_(other.r_item_wt_),
+  idx_(other.idx_),
+  final_idx_(other.final_idx_)
+{}
+
+template<typename T,  typename S, typename A>
+typename var_opt_sketch<T, S, A>::iterator& var_opt_sketch<T, S, A>::iterator::operator++() {
+  ++idx_;
+  
+  if (idx_ == final_idx_) {
+    sk_ = nullptr;
+    return *this;
+  } else if (idx_ == sk_->h_ && sk_->r_ > 0) { // check for the gap
+    ++idx_;
+  }
+  if (idx_ > sk_->h_) { cum_r_weight_ += r_item_wt_; }
+  return *this;
+}
+
+template<typename T,  typename S, typename A>
+typename var_opt_sketch<T, S, A>::iterator& var_opt_sketch<T, S, A>::iterator::operator++(int) {
+  const_iterator tmp(*this);
+  operator++();
+  return tmp;
+}
+
+template<typename T, typename S, typename A>
+bool var_opt_sketch<T, S, A>::iterator::operator==(const iterator& other) const {
+  if (sk_ != other.sk_) return false;
+  if (sk_ == nullptr) return true; // end (and we know other.sk_ is also null)
+  return idx_ == other.idx_;
+}
+
+template<typename T, typename S, typename A>
+bool var_opt_sketch<T, S, A>::iterator::operator!=(const iterator& other) const {
+  return !operator==(other);
+}
+
+template<typename T, typename S, typename A>
+std::pair<T&, double> var_opt_sketch<T, S, A>::iterator::operator*() {
+  double wt;
+  if (idx_ < sk_->h_) {
+    wt = sk_->weights_[idx_];
+  } else if (idx_ == final_idx_ - 1) {
+    wt = sk_->total_wt_r_ - cum_r_weight_;
+  } else {
+    wt = r_item_wt_;
+  }
+  return std::pair<T&, double>(sk_->data_[idx_], wt);
+}
+
+template<typename T, typename S, typename A>
+bool var_opt_sketch<T, S, A>::iterator::get_mark() const {
+  return sk_->marks_ == nullptr ? false : sk_->marks_[idx_];
+}
+
 
 
 // ******************** MOVE TO COMMON UTILS AREA EVENTUALLY *********************

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -744,7 +744,6 @@ string<A> var_opt_sketch<T,S,A>::to_string() const {
 
 template<typename T, typename S, typename A>
 string<A> var_opt_sketch<T,S,A>::items_to_string() const {
-  return items_to_string(true);
   std::basic_ostringstream<char, std::char_traits<char>, AllocChar<A>> os;
   os << "### Sketch Items" << std::endl;
   int idx = 0;

--- a/sampling/include/var_opt_sketch_impl.hpp
+++ b/sampling/include/var_opt_sketch_impl.hpp
@@ -1502,8 +1502,7 @@ var_opt_sketch<T,S,A>::const_iterator::const_iterator(const var_opt_sketch<T,S,A
   sk_(&sk),
   cum_r_weight_(0.0),
   r_item_wt_(sk.get_tau()),
-  final_idx_(sk.r_ > 0 ? sk.h_ + sk.r_ + 1 : sk.h_),
-  weight_correction_(false)
+  final_idx_(sk.r_ > 0 ? sk.h_ + sk.r_ + 1 : sk.h_)
 {
   // index logic easier to read if not inline
   if (is_end) {
@@ -1518,12 +1517,11 @@ var_opt_sketch<T,S,A>::const_iterator::const_iterator(const var_opt_sketch<T,S,A
 }
 
 template<typename T, typename S, typename A>
-var_opt_sketch<T,S,A>::const_iterator::const_iterator(const var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region, bool weight_corr) :
+var_opt_sketch<T,S,A>::const_iterator::const_iterator(const var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region) :
   sk_(&sk),
   cum_r_weight_(0.0),
   r_item_wt_(sk.get_tau()),
-  final_idx_(sk.h_ + (use_r_region ? 1 + sk.r_ : 0)),
-  weight_correction_(weight_corr)
+  final_idx_(sk.h_ + (use_r_region ? 1 + sk.r_ : 0))
 {
   if (use_r_region) {
     idx_ = sk.h_ + 1 + (is_end ? sk.r_ : 0);
@@ -1543,8 +1541,7 @@ var_opt_sketch<T, S, A>::const_iterator::const_iterator(const const_iterator& ot
   cum_r_weight_(other.cum_r_weight_),
   r_item_wt_(other.r_item_wt_),
   idx_(other.idx_),
-  final_idx_(other.final_idx_),
-  weight_correction_(other.weight_correction_)
+  final_idx_(other.final_idx_)
 {}
 
 template<typename T,  typename S, typename A>
@@ -1585,8 +1582,6 @@ const std::pair<const T&, const double> var_opt_sketch<T, S, A>::const_iterator:
   double wt;
   if (idx_ < sk_->h_) {
     wt = sk_->weights_[idx_];
-  } else if (weight_correction_ && idx_ == final_idx_ - 1) {
-    wt = sk_->total_wt_r_ - cum_r_weight_;
   } else {
     wt = r_item_wt_;
   }
@@ -1602,7 +1597,7 @@ bool var_opt_sketch<T, S, A>::const_iterator::get_mark() const {
 // -------- var_opt_sketch::iterator implementation ---------
 
 template<typename T, typename S, typename A>
-var_opt_sketch<T,S,A>::iterator::iterator(var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region) :
+var_opt_sketch<T,S,A>::iterator::iterator(const var_opt_sketch<T,S,A>& sk, bool is_end, bool use_r_region) :
   sk_(&sk),
   cum_r_weight_(0.0),
   r_item_wt_(sk.get_tau()),

--- a/sampling/include/var_opt_union.hpp
+++ b/sampling/include/var_opt_union.hpp
@@ -68,12 +68,11 @@ public:
   void update(const var_opt_sketch<T,S,A>& sk);
   
   /**
-   * Not yet implemented
    * Updates this union with the given sketch
    * This method takes an rvalue.
    * @param sk a sketch to add to the union
    */
-  //void update(var_opt_sketch<T,S,A>&& sk);
+  void update(var_opt_sketch<T,S,A>&& sk);
 
   /**
    * Gets the varopt sketch resulting from the union of any input sketches.
@@ -216,7 +215,9 @@ private:
    more importantly, this design choice allows us to exactly re-construct the input sketch
    when there is only one of them.
    */
-  void merge_into(const var_opt_sketch<T,S,A>& sk);
+  inline void merge_items(const var_opt_sketch<T,S,A>& sk);
+  inline void merge_items(var_opt_sketch<T,S,A>&& sk);
+  inline void resolve_tau(const var_opt_sketch<T,S,A>& sketch);
 
   double get_outer_tau() const;
 

--- a/sampling/include/var_opt_union_impl.hpp
+++ b/sampling/include/var_opt_union_impl.hpp
@@ -342,18 +342,18 @@ void var_opt_union<T,S,A>::merge_items(const var_opt_sketch<T,S,A>& sketch) {
 
   n_ += sketch.n_;
 
-  // H region iterator
-  typename var_opt_sketch<T,S,A>::const_iterator h_itr(sketch, false, false, false);
-  typename var_opt_sketch<T,S,A>::const_iterator h_end(sketch, true, false, false);
+  // H region const_iterator
+  typename var_opt_sketch<T,S,A>::const_iterator h_itr(sketch, false, false);
+  typename var_opt_sketch<T,S,A>::const_iterator h_end(sketch, true, false);
   while (h_itr != h_end) {
     std::pair<const T&, const double> sample = *h_itr;
     gadget_.update(sample.first, sample.second, false);
     ++h_itr;
   }
 
-  // Weight-correcitng R region iterator
-  typename var_opt_sketch<T,S,A>::const_iterator r_itr(sketch, false, true, true);
-  typename var_opt_sketch<T,S,A>::const_iterator r_end(sketch, true, true, true);
+  // Weight-correcting R region iterator (const_iterator doesn't do the correction)
+  typename var_opt_sketch<T,S,A>::iterator r_itr(sketch, false, true);
+  typename var_opt_sketch<T,S,A>::iterator r_end(sketch, true, true);
   while (r_itr != r_end) {
     std::pair<const T&, const double> sample = *r_itr;
     gadget_.update(sample.first, sample.second, true);
@@ -378,7 +378,7 @@ void var_opt_union<T,S,A>::merge_items(var_opt_sketch<T,S,A>&& sketch) {
     ++h_itr;
   }
 
-  // Weight-correcitng R region iterator
+  // Weight-correcting R region iterator
   typename var_opt_sketch<T,S,A>::iterator r_itr(sketch, false, true);
   typename var_opt_sketch<T,S,A>::iterator r_end(sketch, true, true);
   while (r_itr != r_end) {

--- a/sampling/include/var_opt_union_impl.hpp
+++ b/sampling/include/var_opt_union_impl.hpp
@@ -315,7 +315,14 @@ string<A> var_opt_union<T,S,A>::to_string() const {
 
 template<typename T, typename S, typename A>
 void var_opt_union<T,S,A>::update(const var_opt_sketch<T,S,A>& sk) {
-  merge_into(sk);
+  merge_items(sk);
+  resolve_tau(sk);
+}
+
+template<typename T, typename S, typename A>
+void var_opt_union<T,S,A>::update(var_opt_sketch<T,S,A>&& sk) {
+  merge_items(std::move(sk));
+  resolve_tau(sk); // don't need items, so ok even if they've been moved out
 }
 
 template<typename T, typename S, typename A>
@@ -328,7 +335,7 @@ double var_opt_union<T,S,A>::get_outer_tau() const {
 }
 
 template<typename T, typename S, typename A>
-void var_opt_union<T,S,A>::merge_into(const var_opt_sketch<T,S,A>& sketch) {
+void var_opt_union<T,S,A>::merge_items(const var_opt_sketch<T,S,A>& sketch) {
   if (sketch.n_ == 0) {
     return;
   }
@@ -352,8 +359,37 @@ void var_opt_union<T,S,A>::merge_into(const var_opt_sketch<T,S,A>& sketch) {
     gadget_.update(sample.first, sample.second, true);
     ++r_itr;
   }
+}
 
-  // resolve tau
+template<typename T, typename S, typename A>
+void var_opt_union<T,S,A>::merge_items(var_opt_sketch<T,S,A>&& sketch) {
+  if (sketch.n_ == 0) {
+    return;
+  }
+
+  n_ += sketch.n_;
+
+  // H region iterator
+  typename var_opt_sketch<T,S,A>::iterator h_itr(sketch, false, false);
+  typename var_opt_sketch<T,S,A>::iterator h_end(sketch, true, false);
+  while (h_itr != h_end) {
+    std::pair<T&, double> sample = *h_itr;
+    gadget_.update(std::move(sample.first), sample.second, false);
+    ++h_itr;
+  }
+
+  // Weight-correcitng R region iterator
+  typename var_opt_sketch<T,S,A>::iterator r_itr(sketch, false, true);
+  typename var_opt_sketch<T,S,A>::iterator r_end(sketch, true, true);
+  while (r_itr != r_end) {
+    std::pair<T&, double> sample = *r_itr;
+    gadget_.update(std::move(sample.first), sample.second, true);
+    ++r_itr;
+  }
+}
+
+template<typename T, typename S, typename A>
+void var_opt_union<T,S,A>::resolve_tau(const var_opt_sketch<T,S,A>& sketch) {
   if (sketch.r_ > 0) {
     const double sketch_tau = sketch.get_tau();
     const double outer_tau = get_outer_tau();
@@ -436,7 +472,7 @@ bool var_opt_union<T,S,A>::detect_and_handle_subcase_of_pseudo_exact(var_opt_ske
   const bool condition2 = gadget_.num_marks_in_h_ > 0;
 
   // if gadget is pseudo-exact and the number of marks equals outer_tau_denom, then we can deduce
-  // from the bookkeeping logic of merge_into() that all estimation mode input sketches must
+  // from the bookkeeping logic of resolve_tau() that all estimation mode input sketches must
   // have had the same tau, so we can throw all of the marked items into a common reservoir.
   const bool condition3 = gadget_.num_marks_in_h_ == outer_tau_denom_;
 

--- a/sampling/test/var_opt_union_test.cpp
+++ b/sampling/test/var_opt_union_test.cpp
@@ -1,4 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #include <var_opt_union.hpp>
+#include "test_type.hpp"
 
 #include <catch.hpp>
 
@@ -303,6 +323,31 @@ TEST_CASE("varopt union: deserialize from java", "[var_opt_union]") {
   REQUIRE(ss.estimate == Approx(expected_wt).margin(EPS));
   REQUIRE(ss.total_sketch_weight == Approx(expected_wt + 1024.0).margin(EPS));
   REQUIRE(result.get_k() < 128);
+}
+
+TEST_CASE( "varopt union: move", "[var_opt_union][test_type]") {
+  int n = 20;
+  uint32_t k = 5;
+  var_opt_union<test_type> u(k);
+  var_opt_sketch<test_type> sk1(k);
+  var_opt_sketch<test_type> sk2(k);
+
+  // move udpates
+  for (int i = 0; i < n; ++i) {
+    sk1.update(i);
+    sk2.update(-i);
+  }
+
+  // move unions
+  u.update(std::move(sk2));
+  u.update(std::move(sk1));
+
+  // move constructor
+  var_opt_union<test_type> u2(std::move(u));
+
+  // move assignment
+  var_opt_union<test_type> u3(k);
+  u3 = std::move(u2);
 }
 
 }

--- a/sampling/test/var_opt_union_test.cpp
+++ b/sampling/test/var_opt_union_test.cpp
@@ -337,22 +337,22 @@ TEST_CASE( "varopt union: move", "[var_opt_union][test_type]") {
     sk1.update(i);
     sk2.update(-i);
   }
-  REQUIRE(sk1.get_num_samples() == n);
-  REQUIRE(sk2.get_num_samples() == n);
+  REQUIRE(sk1.get_n() == n);
+  REQUIRE(sk2.get_n() == n);
 
   // move unions
   u.update(std::move(sk2));
   u.update(std::move(sk1));
-  REQUIRE(u.get_result().get_num_samples() == 2 * n);
+  REQUIRE(u.get_result().get_n() == 2 * n);
 
   // move constructor
   var_opt_union<test_type> u2(std::move(u));
-  REQUIRE(u2.get_result().get_num_samples() == 2 * n);
+  REQUIRE(u2.get_result().get_n() == 2 * n);
 
   // move assignment
   var_opt_union<test_type> u3(k);
   u3 = std::move(u2);
-  REQUIRE(u3.get_result().get_num_samples() == 2 * n);
+  REQUIRE(u3.get_result().get_n() == 2 * n);
 }
 
 }

--- a/sampling/test/var_opt_union_test.cpp
+++ b/sampling/test/var_opt_union_test.cpp
@@ -326,28 +326,33 @@ TEST_CASE("varopt union: deserialize from java", "[var_opt_union]") {
 }
 
 TEST_CASE( "varopt union: move", "[var_opt_union][test_type]") {
-  int n = 20;
+  uint32_t n = 20;
   uint32_t k = 5;
   var_opt_union<test_type> u(k);
   var_opt_sketch<test_type> sk1(k);
   var_opt_sketch<test_type> sk2(k);
 
   // move udpates
-  for (int i = 0; i < n; ++i) {
+  for (int i = 0; i < (int) n; ++i) {
     sk1.update(i);
     sk2.update(-i);
   }
+  REQUIRE(sk1.get_num_samples() == n);
+  REQUIRE(sk2.get_num_samples() == n);
 
   // move unions
   u.update(std::move(sk2));
   u.update(std::move(sk1));
+  REQUIRE(u.get_result().get_num_samples() == 2 * n);
 
   // move constructor
   var_opt_union<test_type> u2(std::move(u));
+  REQUIRE(u2.get_result().get_num_samples() == 2 * n);
 
   // move assignment
   var_opt_union<test_type> u3(k);
   u3 = std::move(u2);
+  REQUIRE(u3.get_result().get_num_samples() == 2 * n);
 }
 
 }


### PR DESCRIPTION
I also played with to_string() a bit -- there's an internal one that gives a bit more info and the public one that uses the iterator. I'm fine killing the private one and hacking something manually if debugging in the future.

Had to either add a private iterator or basically re-implement the same logic.  The const_iterator is the only public one. The non-moving merge does use the non-const iterator for part of the merge (without explicitly invoking std::move). If that seems at all unsafe I can roll back that part.