### PR TITLE
Added unit tests for Python kll_sketches

### DIFF
--- a/python/tests/kll_test.py
+++ b/python/tests/kll_test.py
@@ -16,18 +16,21 @@
 # under the License.
 
 import unittest
-from datasketches import kll_ints_sketch, kll_floats_sketch
+from datasketches import (kll_ints_sketch, kll_floats_sketch, 
+                          kll_intarray_sketches,
+                          kll_floatarray_sketches)
+import numpy as np
+
 
 class KllTest(unittest.TestCase):
     def test_kll_example(self):
-      from numpy.random import randn
       k = 160
       n = 2 ** 20
 
       # create a sketch and inject ~1 million N(0,1) points
       kll = kll_floats_sketch(k)
       for i in range(0, n):
-        kll.update(randn())
+        kll.update(np.random.randn())
 
       # 0 should be near the median
       self.assertAlmostEqual(0.5, kll.get_rank(0.0), delta=0.025)
@@ -113,6 +116,94 @@ class KllTest(unittest.TestCase):
       k = 75
       kll = kll_floats_sketch(k)
       self.assertTrue(kll.is_empty())
-        
+
+
+class KllSketchesTest(unittest.TestCase):
+    def test_kll_sketches_example(self):
+      k = 200
+      d = 3
+      n = 2 ** 20
+
+      # create a sketch and inject ~1 million N(0,1) points
+      kll = kll_floatarray_sketches(k, d)
+      # Track the min/max for each sketch to test later
+      smin = np.zeros(d) + np.inf
+      smax = np.zeros(d) - np.inf
+
+      for i in range(0, n):
+        dat  = np.random.randn(d)
+        smin = np.amin([smin, dat], axis=0)
+        smax = np.amax([smax, dat], axis=0)
+        kll.update(dat)
+
+      # 0 should be near the median
+      np.testing.assert_allclose(0.5, kll.get_ranks(0.0), atol=0.025)
+      # the median should be near 0
+      np.testing.assert_allclose(0.0, kll.get_quantiles(0.5), atol=0.025)
+      # we also track the min/max independently from the rest of the data
+      # which lets us know the full observed data range
+      np.testing.assert_allclose(kll.get_min_values(), smin)
+      np.testing.assert_allclose(kll.get_max_values(), smax)
+      np.testing.assert_array_less(kll.get_min_values(), kll.get_quantiles(0.01)[:,0])
+      np.testing.assert_array_less(kll.get_quantiles(0.99)[:,0], kll.get_max_values())
+
+      # we can also extract a list of values at a time,
+      # here the values should give us something close to [-2, -1, 0, 1, 2].
+      # then get the CDF, which will return something close to
+      # the original values used in get_quantiles()
+      # finally, can check the normalized rank error bound
+      pts = kll.get_quantiles([0.0228, 0.1587, 0.5, 0.8413, 0.9772])
+      # use the mean pts for the CDF, include 1.0 at end to account for all probability mass
+      meanpts = np.mean(pts, axis=0)
+      cdf = kll.get_cdf(meanpts)
+      self.assertEqual(cdf.shape[0], pts.shape[0])
+      self.assertEqual(cdf.shape[1], pts.shape[1]+1)
+
+      #err = kll.normalized_rank_error(False)  # method not implemented
+      #self.assertEqual(err, kll.get_normalized_rank_error(k, False))
+
+      # and a few basic queries about the sketch
+      self.assertFalse(np.all(kll.is_empty()))
+      self.assertTrue(np.all(kll.is_estimation_mode()))
+      self.assertTrue(np.all(kll.get_n() == n))
+      self.assertTrue(np.all(kll.get_num_retained() < n))
+
+      # Merging not yet implemented
+      # merging itself will double the number of items the sketch has seen
+      #kll.merge(kll)
+      #self.assertEqual(kll.get_n(), 2*n)
+
+      # we can then serialize and reconstruct the sketch
+      kll_bytes = kll.serialize() # serializes each sketch as a list
+      # store values we are interested in
+      oldkll_num_retained = kll.get_num_retained()
+      oldkll_min_values   = kll.get_min_values()
+      oldkll_max_values   = kll.get_max_values()
+      oldkll_quantiles    = kll.get_quantiles(0.7)
+      oldkll_ranks        = kll.get_ranks(0.0)
+      # deserialize the sketches
+      for s in range(len(kll_bytes)):
+        kll.deserialize(kll_bytes[s], s)
+      np.testing.assert_allclose(oldkll_num_retained, kll.get_num_retained())
+      np.testing.assert_allclose(oldkll_min_values, kll.get_min_values())
+      np.testing.assert_allclose(oldkll_max_values, kll.get_max_values())
+      np.testing.assert_allclose(oldkll_quantiles, kll.get_quantiles(0.7))
+      np.testing.assert_allclose(oldkll_ranks, kll.get_ranks(0.0))
+
+    def test_kll_ints_sketches(self):
+      # already tested floats and it's templatized, so just make sure it instantiates properly
+      k = 100
+      d = 5
+      kll = kll_intarray_sketches(k, d)
+      self.assertTrue(np.all(kll.is_empty()))
+
+    def test_kll_floats_sketches(self):
+      # already tested in the example
+      k = 75
+      d = 3
+      kll = kll_floatarray_sketches(k, d)
+      self.assertTrue(np.all(kll.is_empty()))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I adapted the existing unit tests for the Python kll_sketch class to work for the new array-compatible kll_sketches class.  Note that some tests were unable to be adapted because they are not implemented (merging, and comparing the normalized_rank_error method result to the get_normalized_rank_error static method result).