### PR TITLE
Small workflow change

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -31,7 +31,7 @@ jobs:
         run: cmake --build build --target test
       - name: Generate coverage .info
         run: cmake --build build --target coverage_report
-      - name: Coveralls
+      - name: Post to Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Rename the "Coveralls" step to "Post to Coveralls" to better describe what happens.