### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Install Python dependencies
         run: python -m pip install --upgrade pip setuptools wheel numpy tox
       - name: Build and run Python tests
-        run: tox
+        run: python -m tox

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run C++ tests
         run: cmake --build build --config Release --target ${{ matrix.config.test_target }}
       - name: Set up Python 3.x
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '3.x' # grabs latest minor version of python3
       - name: Install Python dependencies

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x' # grabs latest minor version of python3
+          python-version: '3.8' # 3.x grabs latest minor version of python3, but 3.9 not fully supported yet
       - name: Install Python dependencies
         run: python -m pip install --upgrade pip setuptools wheel numpy tox
       - name: Build and run Python tests


### PR DESCRIPTION
Updated a few things to newer versions, but the real issue is that python 3.9 is released and is the "default" for the github build action, but the full python toolchain has not yet been updated to support it.

Leaving the other changes in place, but for now the short-term solution was to fix our python version at 3.8. Should probably test a few versions eventually but that's not an immediate blocker at least.